### PR TITLE
Residue kind is now updated after changing name

### DIFF
--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -1,6 +1,16 @@
 require "../spec_helper"
 
 describe Chem::Residue do
+  describe ".new" do
+    it "sets kind from templates" do
+      structure = Chem::Structure.new
+      chain = Chem::Chain.new 'A', structure
+      Chem::Residue.new("TYR", 1, chain).kind.protein?.should be_true
+      Chem::Residue.new("HOH", 2, chain).kind.solvent?.should be_true
+      Chem::Residue.new("ULK", 2, chain).kind.other?.should be_true
+    end
+  end
+
   describe "#bonded?" do
     it "tells if two residues are bonded through any pair of atoms" do
       structure = fake_structure include_bonds: true
@@ -42,6 +52,19 @@ describe Chem::Residue do
 
     it "returns false when residue is at the start" do
       load_file("cis-trans.pdb", topology: :templates).residues[0].cis?.should be_false
+    end
+  end
+
+  describe "#name=" do
+    it "sets kind from templates" do
+      structure = Structure.new
+      chain = Chain.new 'A', structure
+      residue = Chem::Residue.new("TYR", 1, chain)
+      residue.kind.protein?.should be_true
+      residue.name = "HOH"
+      residue.kind.solvent?.should be_true
+      residue.name = "ULK"
+      residue.kind.other?.should be_true
     end
   end
 

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -33,6 +33,7 @@ module Chem
                    @number : Int32,
                    @insertion_code : Char?,
                    @chain : Chain)
+      assign_kind_from_templates
       @chain << self
     end
 
@@ -105,6 +106,12 @@ module Chem
 
     def n_atoms : Int32
       @atoms.size
+    end
+
+    def name=(str : String) : String
+      @name = str
+      assign_kind_from_templates
+      str
     end
 
     def omega : Float64
@@ -185,6 +192,10 @@ module Chem
         @kind == Kind::{{member}}
       end
     {% end %}
+
+    private def assign_kind_from_templates : Nil
+      @kind = Topology::Templates[@name]?.try(&.kind) || Residue::Kind::Other
+    end
 
     protected def reset_cache : Nil
       @atom_table.clear

--- a/src/chem/core/structure/builder.cr
+++ b/src/chem/core/structure/builder.cr
@@ -120,13 +120,7 @@ module Chem
     end
 
     def residue(name : String, number : Int32, inscode : Char? = nil) : Residue
-      @residue = chain[number, inscode]? || begin
-        residue = Residue.new(name, number, inscode, chain)
-        if res_t = Topology::Templates[name]?
-          residue.kind = Residue::Kind.from_value res_t.kind.to_i
-        end
-        residue
-      end
+      @residue = chain[number, inscode]? || Residue.new(name, number, inscode, chain)
     end
 
     def residue(name : String, number : Int32, inscode : Char? = nil, & : self ->) : Nil

--- a/src/chem/topology/guesser.cr
+++ b/src/chem/topology/guesser.cr
@@ -67,7 +67,6 @@ module Chem::Topology::Guesser
     unknown_residues = [] of Residue
     structure.each_residue do |residue|
       if res_t = Templates[residue.name]?
-        residue.kind = res_t.kind
         assign_bonds residue, res_t
         assign_formal_charges residue, res_t
       else


### PR DESCRIPTION
Residue kind is now auto-assigned only within the `Residue` class at construction and after changing name. This ensure that kind is synchronized to the residue's name, which dictates its kind.