### PR TITLE
Added methods to get neighbors and distances

### DIFF
--- a/spec/spatial/kdtree_spec.cr
+++ b/spec/spatial/kdtree_spec.cr
@@ -99,4 +99,64 @@ describe Chem::Spatial::KDTree do
       end
     end
   end
+
+  describe "#nearest_with_distance" do
+    it "returns closest neighbor + distance to a point" do
+      structure = Structure.build do
+        lattice 2, 2, 2
+        atom :C, V[1, 1, 1]
+        atom :H, V[1.5, 0.5, 0.5]
+      end
+      c, h = structure.atoms
+
+      kdtree = KDTree.new structure, periodic: true
+      kdtree.nearest_with_distance(V[0, 0, 0]).should eq({h, 0.75})
+      kdtree.nearest_with_distance(V[1, 1, 1]).should eq({c, 0})
+      kdtree.nearest_with_distance(V[2, 0, 0]).should eq({h, 0.75})
+    end
+
+    it "returns closest neighbor + distance to an atom" do
+      structure = Structure.build do
+        lattice 2, 2, 2
+        atom :C, V[1, 1, 1]
+        atom :H, V[1.5, 0.5, 0.5]
+      end
+      c, h = structure.atoms
+
+      kdtree = KDTree.new structure, periodic: true
+      kdtree.nearest_with_distance(c).should eq({h, 0.75})
+      kdtree.nearest_with_distance(h).should eq({c, 0.75})
+    end
+  end
+
+  describe "#neighbors_with_distance" do
+    it "returns N closest neighbors + distances to a point" do
+      structure = Structure.build do
+        lattice 2, 2, 2
+        atom :C, V[1, 1, 1]
+        atom :H, V[1.5, 0.5, 0.5]
+      end
+      c, h = structure.atoms
+
+      kdtree = KDTree.new structure, periodic: true
+      kdtree.neighbors_with_distance(V[0, 0, 0], n: 2).should eq [{h, 0.75}, {h, 2.75}]
+      kdtree.neighbors_with_distance(V[1, 1, 1], n: 2).should eq [{c, 0}, {h, 0.75}]
+      kdtree.neighbors_with_distance(V[2, 0, 0], n: 2).should eq [{h, 0.75}, {c, 3.0}]
+      neighbors = kdtree.neighbors_with_distance(V[0.141, 1.503, 1.801], n: 2)
+      neighbors.map(&.[0]).should eq [c, h]
+      neighbors.map(&.[1]).should be_close [1.633, 1.893], 1e-3
+    end
+
+    it "returns N closest neighbors + distances to an atom" do
+      structure = Structure.build do
+        lattice 2, 2, 2
+        atom :C, V[1, 1, 1]
+        atom :H, V[1.5, 0.5, 0.5]
+      end
+      c, h = structure.atoms
+
+      kdtree = KDTree.new structure, periodic: true
+      kdtree.neighbors_with_distance(c, n: 2).should eq [{h, 0.75}, {h, 2.75}]
+    end
+  end
 end

--- a/src/chem/spatial/kdtree.cr
+++ b/src/chem/spatial/kdtree.cr
@@ -87,6 +87,10 @@ module Chem::Spatial
       neighbors(coords, count: 1).first
     end
 
+    def nearest_with_distance(atom : Atom | Vector) : Tuple(Atom, Float64)
+      neighbors_with_distance(atom, n: 1).first
+    end
+
     def neighbors(of atom : Atom, *, count : Int) : Array(Atom)
       neighbors(atom.coords, count: count + 1).reject! &.==(atom)
     end
@@ -107,6 +111,16 @@ module Chem::Spatial
         neighbors << {atom, distance}
       end
       neighbors.sort_by!(&.[1]).map &.[0]
+    end
+
+    def neighbors_with_distance(atom : Atom, *, n : Int) : Array(Tuple(Atom, Float64))
+      neighbors_with_distance(atom.coords, n: n + 1).reject! &.[0].==(atom)
+    end
+
+    def neighbors_with_distance(vec : Vector, *, n : Int) : Array(Tuple(Atom, Float64))
+      neighbors = Array(Tuple(Atom, Float64)).new n
+      search @root, vec, n, neighbors
+      neighbors
     end
 
     private def build_tree(atoms : Array(Tuple(Vector, Atom)),


### PR DESCRIPTION
Currently, one needs to test every PBC image to get the smallest (correct) distance for each neighbor from a k-d tree search when dealing with periodic conditions. This PR adds `*_with_distance` methods that return neighbors along with the calculated distances, e.g.,

```crystal
kdtree = KDTree.new structure, periodic: true
vec = V[0.5, 1.25, 0.234]
# before (incorrect when closest neighbor is an atom's image)
atom = kdtree.nearest vec
Spatial.distance vec, atom.coords # => 2.553
# after
atom, d = kdtree.nearest_with_distance vec
d #=> 0.342
```