### PR TITLE
Added Lattice#bounds

### DIFF
--- a/spec/core/lattice_spec.cr
+++ b/spec/core/lattice_spec.cr
@@ -55,12 +55,4 @@ describe Chem::Lattice do
       lattice.basis.should eq Basis.new(V[10, 0, 0], V[0, 20, 0], V[1, 2, 3])
     end
   end
-
-  describe "#volume" do
-    it "returns lattice's volume" do
-      Lattice.new(S[10, 20, 30]).volume.should eq 6_000
-      Lattice.new(S[5, 5, 8], 90, 90, 120).volume.should be_close 173.2050807569, 1e-10
-      Lattice.new(S[1, 2, 3], beta: 101.2).volume.should be_close 5.8857309321, 1e-10
-    end
-  end
 end

--- a/spec/core/lattice_spec.cr
+++ b/spec/core/lattice_spec.cr
@@ -17,6 +17,13 @@ describe Chem::Lattice do
     end
   end
 
+  describe "#bounds" do
+    it "returns the bounds" do
+      Lattice.new(S[1, 2, 3]).bounds.should eq Bounds[1, 2, 3]
+      Lattice.new(S[5, 1, 5], 90, 120, 90).bounds.should eq Bounds.new(S[5, 1, 5], 90, 120, 90)
+    end
+  end
+
   describe "#c=" do
     it "sets the size of the third basis vector" do
       lattice = Lattice.new(S[10, 20, 30])

--- a/spec/spatial/bounds_spec.cr
+++ b/spec/spatial/bounds_spec.cr
@@ -83,6 +83,8 @@ describe Chem::Spatial::Bounds do
   describe "#volume" do
     it "returns the volume enclosed by the bounds" do
       Bounds[10, 20, 30].volume.should eq 6_000
+      Bounds.new(S[5, 5, 8], 90, 90, 120).volume.should be_close 173.2050807569, 1e-10
+      Bounds.new(S[1, 2, 3], beta: 101.2).volume.should be_close 5.8857309321, 1e-10
       Bounds.new(V[1, 2, 3], S[6, 3, 23]).volume.should eq 414
     end
   end

--- a/src/chem/core/lattice.cr
+++ b/src/chem/core/lattice.cr
@@ -72,9 +72,5 @@ module Chem
     def triclinic? : Bool
       !cuboid? && !monoclinic? && !hexagonal?
     end
-
-    def volume : Float64
-      @basis.i.dot @basis.j.cross(@basis.k)
-    end
   end
 end

--- a/src/chem/core/lattice.cr
+++ b/src/chem/core/lattice.cr
@@ -21,6 +21,10 @@ module Chem
       value
     end
 
+    def bounds : Spatial::Bounds
+      Spatial::Bounds.new Spatial::Vector.origin, @basis
+    end
+
     def c=(value : Float64) : Float64
       @basis = Spatial::Basis.new i, j, k.resize(value)
       value

--- a/src/chem/core/lattice.cr
+++ b/src/chem/core/lattice.cr
@@ -30,10 +30,6 @@ module Chem
       value
     end
 
-    def center : Spatial::Vector
-      (@basis.i + @basis.j + @basis.k) * 0.5
-    end
-
     def cubic? : Bool
       a == b && b == c && cuboid?
     end

--- a/src/chem/spatial/coordinates_proxy.cr
+++ b/src/chem/spatial/coordinates_proxy.cr
@@ -129,7 +129,7 @@ module Chem::Spatial
     end
 
     def wrap(lattice : Lattice, around center : Vector? = nil) : self
-      center ||= lattice.center
+      center ||= lattice.bounds.center
 
       if lattice.cuboid?
         vecs = {lattice.i, lattice.j, lattice.k}

--- a/src/chem/spatial/pbc.cr
+++ b/src/chem/spatial/pbc.cr
@@ -20,7 +20,7 @@ module Chem::Spatial::PBC
   def each_adjacent_image(atoms : AtomCollection,
                           lattice : Lattice,
                           &block : Atom, Vector ->)
-    offset = (lattice.center - atoms.coords.center).to_fractional lattice
+    offset = (lattice.bounds.center - atoms.coords.center).to_fractional lattice
     atoms.each_atom do |atom|
       fcoords = atom.coords.to_fractional lattice                     # convert to fractional coords
       w_fcoords = fcoords - fcoords.floor                             # wrap to primary unit cell
@@ -46,7 +46,7 @@ module Chem::Spatial::PBC
     raise Error.new "Radius cannot be negative" if radius < 0
 
     padding = Vector[radius / lattice.a, radius / lattice.b, radius / lattice.c].clamp(..0.5)
-    offset = (lattice.center - atoms.coords.center).to_fractional lattice
+    offset = (lattice.bounds.center - atoms.coords.center).to_fractional lattice
     atoms.each_atom do |atom|
       fcoords = atom.coords.to_fractional lattice                     # convert to fractional coords
       w_fcoords = fcoords - fcoords.floor                             # wrap to primary unit cell


### PR DESCRIPTION
Utility method to get bounds (assumed to be centered at the origin). This helps to remove duplicate functionality between `Bounds` and `Lattice`, i.e., `#center` and `#volume`