### PR TITLE
Auto-enable PBC support in KDTree

### DIFF
--- a/bench/search_dist_bench.cr
+++ b/bench/search_dist_bench.cr
@@ -7,7 +7,7 @@ alias Vector = Chem::Spatial::Vector
 structure = Chem::Structure.read "spec/data/pdb/1h1s.pdb"
 atoms = structure.atoms
 atoms_as_a = atoms.to_a
-tree = KDTree.new structure
+tree = KDTree.new structure, periodic: false
 
 cr_data = Hash.zip (0...atoms.size).to_a.map(&.to_f), atoms.map(&.coords.to_a)
 cr_tree = Crystalline::KDTree(Float64).new cr_data

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -33,7 +33,7 @@ describe Chem::Spatial::Grid do
     end
 
     it "returns a grid having distances to nearest atom" do
-      st = Chem::Structure.build do
+      st = Chem::Structure.build(guess_topology: false) do
         lattice 2, 2, 2
         atom :C, V[1, 1, 1]
         atom :C, V[1.5, 0.5, 0.5]

--- a/spec/spatial/kdtree_spec.cr
+++ b/spec/spatial/kdtree_spec.cr
@@ -29,7 +29,7 @@ describe Chem::Spatial::KDTree do
 
   context "real example" do
     st = load_file "1h1s.pdb", topology: :none
-    kdtree = KDTree.new st
+    kdtree = KDTree.new st, periodic: false
 
     describe "#each_neighbor" do
       it "yields each atom within the given radius of a point" do
@@ -86,14 +86,14 @@ describe Chem::Spatial::KDTree do
     describe "#neighbors" do
       it "returns the atoms within the given radius of a point sorted by proximity" do
         structure = load_file "AlaIle--wrapped.poscar", topology: :none
-        kdtree = KDTree.new structure, periodic: true, radius: 2.5
+        kdtree = KDTree.new structure, radius: 2.5
         atoms = kdtree.neighbors of: structure.atoms[4], within: 2.5
         atoms.map(&.serial).sort!.should eq [4, 17, 25, 28, 29, 30, 32]
       end
 
       it "returns the atoms within the given radius of a point sorted by proximity" do
         structure = load_file "5e61--wrapped.poscar", topology: :none
-        kdtree = KDTree.new structure, periodic: true, radius: 2
+        kdtree = KDTree.new structure, radius: 2
         atoms = kdtree.neighbors of: structure.atoms[16], within: 2
         atoms.map(&.serial).should eq [86, 87, 88, 16]
       end
@@ -109,7 +109,7 @@ describe Chem::Spatial::KDTree do
       end
       c, h = structure.atoms
 
-      kdtree = KDTree.new structure, periodic: true
+      kdtree = KDTree.new structure
       kdtree.nearest_with_distance(V[0, 0, 0]).should eq({h, 0.75})
       kdtree.nearest_with_distance(V[1, 1, 1]).should eq({c, 0})
       kdtree.nearest_with_distance(V[2, 0, 0]).should eq({h, 0.75})
@@ -123,7 +123,7 @@ describe Chem::Spatial::KDTree do
       end
       c, h = structure.atoms
 
-      kdtree = KDTree.new structure, periodic: true
+      kdtree = KDTree.new structure
       kdtree.nearest_with_distance(c).should eq({h, 0.75})
       kdtree.nearest_with_distance(h).should eq({c, 0.75})
     end
@@ -138,7 +138,7 @@ describe Chem::Spatial::KDTree do
       end
       c, h = structure.atoms
 
-      kdtree = KDTree.new structure, periodic: true
+      kdtree = KDTree.new structure
       kdtree.neighbors_with_distance(V[0, 0, 0], n: 2).should eq [{h, 0.75}, {h, 2.75}]
       kdtree.neighbors_with_distance(V[1, 1, 1], n: 2).should eq [{c, 0}, {h, 0.75}]
       kdtree.neighbors_with_distance(V[2, 0, 0], n: 2).should eq [{h, 0.75}, {c, 3.0}]
@@ -155,7 +155,7 @@ describe Chem::Spatial::KDTree do
       end
       c, h = structure.atoms
 
-      kdtree = KDTree.new structure, periodic: true
+      kdtree = KDTree.new structure
       kdtree.neighbors_with_distance(c, n: 2).should eq [{h, 0.75}, {h, 2.75}]
     end
   end

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -32,7 +32,7 @@ module Chem::Spatial
                            dim : Dimensions,
                            bounds : Bounds? = nil) : self
       grid = new dim, (bounds || structure.coords.bounds)
-      kdtree = KDTree.new structure, periodic: structure.periodic?
+      kdtree = KDTree.new structure
       grid.map_with_coords! do |_, vec|
         Math.sqrt kdtree.nearest_with_distance(vec)[1]
       end

--- a/src/chem/spatial/kdtree.cr
+++ b/src/chem/spatial/kdtree.cr
@@ -33,19 +33,6 @@ module Chem::Spatial
 
     @root : Node
 
-    def initialize(atoms : AtomCollection)
-      initialize atoms.each_atom.map { |atom| {atom.coords, atom} }.to_a
-    end
-
-    def initialize(atoms : AtomCollection, lattice : Lattice, **options)
-      ary = [] of Tuple(Vector, Atom)
-      atoms.each_atom { |atom| ary << {atom.coords, atom} }
-      PBC.each_adjacent_image(atoms, lattice, **options) do |atom, coords|
-        ary << {coords, atom}
-      end
-      initialize ary
-    end
-
     private def initialize(atoms : Array(Tuple(Vector, Atom)))
       if root = build_tree atoms, 0...atoms.size
         @root = root
@@ -54,13 +41,24 @@ module Chem::Spatial
       end
     end
 
-    def initialize(structure : Structure, periodic : Bool = false, **options)
+    def self.new(structure : Structure, periodic : Bool = false, **options)
       if periodic
         raise NotPeriodicError.new unless lattice = structure.lattice
-        initialize structure, lattice, **options
+        new structure, lattice, **options
       else
-        initialize structure
+        new structure.each_atom.map { |atom| {atom.coords, atom} }.to_a
       end
+    end
+
+    def self.new(atoms : AtomCollection, lattice : Lattice? = nil, **options)
+      ary = Array(Tuple(Vector, Atom)).new atoms.n_atoms
+      atoms.each_atom { |atom| ary << {atom.coords, atom} }
+      if lattice
+        PBC.each_adjacent_image(atoms, lattice, **options) do |atom, coords|
+          ary << {coords, atom}
+        end
+      end
+      new ary
     end
 
     def each_neighbor(of atom : Atom,

--- a/src/chem/spatial/kdtree.cr
+++ b/src/chem/spatial/kdtree.cr
@@ -41,7 +41,11 @@ module Chem::Spatial
       end
     end
 
-    def self.new(structure : Structure, periodic : Bool = false, **options)
+    def self.new(structure : Structure, **options) : self
+      new structure, structure.periodic?, **options
+    end
+
+    def self.new(structure : Structure, periodic : Bool, **options)
       if periodic
         raise NotPeriodicError.new unless lattice = structure.lattice
         new structure, lattice, **options

--- a/src/chem/topology/connectivity.cr
+++ b/src/chem/topology/connectivity.cr
@@ -4,7 +4,7 @@ module Chem::Topology
 
     def initialize(structure : Structure, bond_orders : Bool? = nil)
       @bond_orders = bond_orders || structure.each_atom.any?(&.element.hydrogen?)
-      @kdtree = Spatial::KDTree.new structure, structure.periodic?, radius: MAX_COVALENT_RADIUS
+      @kdtree = Spatial::KDTree.new structure, radius: MAX_COVALENT_RADIUS
     end
 
     def detect_bonds(atoms : AtomCollection) : Nil


### PR DESCRIPTION
PBC support is now automatically enabled in KDTree if structure is periodic.

Before one needed to explicitly enable it by passing `periodic: true`, leading to some issues if missed (#9). This PR adds an overload constructor that sets the `periodic` flag depending on whether the structure is periodic or not. Such behavior can be disabled by passing `periodic: false`.