### PR TITLE
Fragment search is now limited to selected atoms

### DIFF
--- a/spec/core/atom_collection_spec.cr
+++ b/spec/core/atom_collection_spec.cr
@@ -14,5 +14,18 @@ describe Chem::AtomCollection do
       expected = [1, 1, 1, 1, 304, 334]
       load_file("k2p_pore_b.xyz", topology: :bonds).fragments.map(&.size).sort!.should eq expected
     end
+
+    it "returns fragments limited to the selected atoms " do
+      atoms = load_file("5e5v.pdb", topology: :bonds).atoms
+      atoms[0..205].fragments.map(&.size).should eq [103, 103]
+      atoms[0..150].fragments.map(&.size).should eq [103, 48]
+      atoms[0..50].fragments.map(&.size).should eq [51]
+      atoms[0..0].fragments.map(&.size).should eq [1]
+
+      ary = atoms[0..10].to_a
+      ary.concat atoms[150..158] # => O=C(i)-N(i+1)-H-CA, sidechain(i) (no CA(i)-CB)
+      ary.concat atoms[210..220] # => H1, H2, HOH, HOH, HOH
+      Chem::AtomView.new(ary).fragments.map(&.size).should eq [11, 5, 4, 1, 1, 3, 3, 3]
+    end
   end
 end

--- a/src/chem/core/atom_collection.cr
+++ b/src/chem/core/atom_collection.cr
@@ -21,16 +21,16 @@ module Chem
     end
 
     def each_fragment(& : AtomView ->) : Nil
-      visited = Set(Atom).new n_atoms
+      atoms = Set(Atom).new(n_atoms).concat each_atom
       each_atom do |atom|
-        next if visited.includes?(atom)
-        visited << atom
+        next unless atoms.includes?(atom)
+        atoms.delete atom
         fragment = [atom]
         fragment.each do |a|
           a.each_bonded_atom do |b|
-            next if visited.includes?(b)
+            next unless atoms.includes?(b)
             fragment << b
-            visited << b
+            atoms.delete b
           end
         end
         yield AtomView.new(fragment.sort_by(&.serial))

--- a/src/chem/core/atom_collection.cr
+++ b/src/chem/core/atom_collection.cr
@@ -33,7 +33,7 @@ module Chem
             atoms.delete b
           end
         end
-        yield AtomView.new(fragment.sort_by(&.serial))
+        yield AtomView.new(fragment.sort_by!(&.serial))
       end
     end
 


### PR DESCRIPTION
Fragment search worked by iteratively adding bonded atoms. However, it didn't check whether bonded atoms were included in the current list of atoms, so for example, having a single fragment of 100 atoms, `structure.atoms[1..10].fragments` would return a list containing 100 atoms instead of 10 atoms.

This PR fixes this issue by having an initial list of _selected_ atoms, which bonded atoms are checked against, and then iteratively removing them as they are visited during the search.