### PR TITLE
Fix typo in residue assignment of unmatched atoms

### DIFF
--- a/spec/topology/perception_spec.cr
+++ b/spec/topology/perception_spec.cr
@@ -270,7 +270,9 @@ describe Topology::Perception do
     it "detects multiple residues for unmatched atoms (#16)" do
       structure = load_file "peptide_unknown_residues.xyz", topology: :guess
       structure.n_residues.should eq 9
-      structure.residues.map(&.name).sort!.should eq %w(ALA ALA LEU LEU SER THR UNK UNK VAL)
+      structure.residues.map(&.name).should eq %w(ALA LEU VAL THR LEU SER ALA UNK UNK)
+      structure.residues[7].n_atoms.should eq 14
+      structure.residues[8].n_atoms.should eq 8
     end
   end
 

--- a/src/chem/topology/perception.cr
+++ b/src/chem/topology/perception.cr
@@ -211,7 +211,7 @@ module Chem::Topology::Perception
     matches = [] of MatchData
     AtomView.new(atoms).each_fragment do |frag|
       atom_map = Hash(String, Atom).new initial_capacity: frag.size
-      atoms.each { |atom| atom_map[atom.name] = atom }
+      frag.each { |atom| atom_map[atom.name] = atom }
       matches << MatchData.new("UNK", :other, atom_map)
     end
     matches


### PR DESCRIPTION
Bug introduced in #27 but not detected by specs; these were updated as well.