### PR TITLE
Rename unmatched atoms after topology perception

### DIFF
--- a/spec/topology/perception_spec.cr
+++ b/spec/topology/perception_spec.cr
@@ -274,6 +274,13 @@ describe Topology::Perception do
       structure.residues[7].n_atoms.should eq 14
       structure.residues[8].n_atoms.should eq 8
     end
+
+    it "renames unmatched atoms" do
+      structure = load_file("peptide_unknown_residues.xyz", topology: :guess)
+      residues = structure.residues.to_a.select!(&.other?)
+      residues[0].atoms.map(&.name).should eq %w(N1 C1 C2 O1 C3 O2 H1 H2 H3 H4 C4 H5 H6 H7)
+      residues[1].atoms.map(&.name).should eq %w(N1 C1 C2 O1 S1 H1 H2 H3)
+    end
   end
 
   describe "#renumber_by_connectivity" do

--- a/src/chem/topology/perception.cr
+++ b/src/chem/topology/perception.cr
@@ -211,7 +211,11 @@ module Chem::Topology::Perception
     matches = [] of MatchData
     AtomView.new(atoms).each_fragment do |frag|
       atom_map = Hash(String, Atom).new initial_capacity: frag.size
-      frag.each { |atom| atom_map[atom.name] = atom }
+      ele_index = Hash(Element, Int32).new default_value: 0
+      frag.each do |atom|
+        name = "#{atom.element.symbol}#{ele_index[atom.element] += 1}"
+        atom_map[name] = atom
+      end
       matches << MatchData.new("UNK", :other, atom_map)
     end
     matches


### PR DESCRIPTION
Atom names are set following the convention `<element><element-wise serial>`, where serial is reset for each residue starting at 1. Note that atoms are processed in the same order as they are listed in the structure

Fixes #17 