### PR TITLE
Grid parsers can now read file header only

### DIFF
--- a/spec/io/dx_spec.cr
+++ b/spec/io/dx_spec.cr
@@ -28,6 +28,30 @@ describe Chem::DX::Parser do
       0, 1, 2, 10, 11, 12, 20, 21, 22, 100, 101, 102, 110, 111, 112, 120, 121, 122,
     ]
   end
+
+  it "parses a DX header" do
+    io = IO::Memory.new <<-EOS
+      # comment line 1
+      # comment line 2
+      # comment line 3
+      object 1 class gridpositions counts 2 3 3
+      origin   0.500   0.300   1.000
+      delta   10.000   0.000   0.000
+      delta    0.000  20.000   0.000
+      delta    0.000   0.000  10.000
+      object 2 class gridconnections counts 2 3 3
+      object 3 class array type double rank 0 items 18 data follows
+            0.00000000      1.00000000      2.00000000
+           10.00000000     11.00000000     12.00000000
+           20.00000000     21.00000000     22.00000000
+          100.00000000    101.00000000    102.00000000
+          110.00000000    111.00000000    112.00000000
+          120.00000000    121.00000000    122.00000000\n
+      EOS
+    info = Grid.info io, :dx
+    info.bounds.should eq Bounds.new(V[0.5, 0.3, 1], S[10, 40, 20])
+    info.dim.should eq({2, 3, 3})
+  end
 end
 
 describe Chem::DX::Writer do

--- a/spec/io/vasp/chgcar_spec.cr
+++ b/spec/io/vasp/chgcar_spec.cr
@@ -11,6 +11,12 @@ describe Chem::VASP::Chgcar do
     grid[1, 0, 0].should be_close 7.6183317989, 1e-10
   end
 
+  it "parses a CHGCAR header" do
+    info = Grid.info "spec/data/vasp/CHGCAR", :chgcar
+    info.bounds.should eq Bounds[10, 10, 10]
+    info.dim.should eq({2, 2, 2})
+  end
+
   it "writes a CHGCAR" do
     st = Chem::Structure.build(guess_topology: false) do
       title "NaCl-O-NaCl"

--- a/spec/io/vasp/locpot_spec.cr
+++ b/spec/io/vasp/locpot_spec.cr
@@ -12,6 +12,12 @@ describe Chem::VASP::Locpot do
     grid[31, 31, 31].should eq -45.337774769
   end
 
+  it "parses a LOCPOT header" do
+    info = Grid.info "spec/data/vasp/LOCPOT", :chgcar
+    info.bounds.should be_close Bounds[2.969, 2.969, 2.969], 1e-3
+    info.dim.should eq({32, 32, 32})
+  end
+
   it "writes a LOCPOT" do
     st = Chem::Structure.build(guess_topology: false) do
       title "NaCl-O-NaCl"

--- a/src/chem/io/formats/dx.cr
+++ b/src/chem/io/formats/dx.cr
@@ -3,6 +3,12 @@ module Chem::DX
   class Parser < Spatial::Grid::Parser
     include IO::AsciiParser
 
+    def info : Spatial::Grid::Info
+      skip_comments
+      dim, bounds = read_header
+      Spatial::Grid::Info.new bounds, dim
+    end
+
     def parse : Spatial::Grid
       skip_comments
       dim, bounds = read_header

--- a/src/chem/io/formats/dx.cr
+++ b/src/chem/io/formats/dx.cr
@@ -1,6 +1,6 @@
 module Chem::DX
   @[IO::FileType(format: DX, ext: [:dx])]
-  class Parser < IO::Parser(Spatial::Grid)
+  class Parser < Spatial::Grid::Parser
     include IO::AsciiParser
 
     def parse : Spatial::Grid

--- a/src/chem/io/formats/vasp/chgcar.cr
+++ b/src/chem/io/formats/vasp/chgcar.cr
@@ -1,6 +1,6 @@
 module Chem::VASP::Chgcar
   @[IO::FileType(format: Chgcar, ext: [:chgcar])]
-  class Parser < IO::Parser(Spatial::Grid)
+  class Parser < Spatial::Grid::Parser
     include IO::AsciiParser
     include VASP::GridParser
 

--- a/src/chem/io/formats/vasp/locpot.cr
+++ b/src/chem/io/formats/vasp/locpot.cr
@@ -1,6 +1,6 @@
 module Chem::VASP::Locpot
   @[IO::FileType(format: Locpot, ext: [:locpot])]
-  class Parser < IO::Parser(Spatial::Grid)
+  class Parser < Spatial::Grid::Parser
     include IO::AsciiParser
     include GridParser
 

--- a/src/chem/io/formats/vasp/utils.cr
+++ b/src/chem/io/formats/vasp/utils.cr
@@ -1,5 +1,10 @@
 module Chem::VASP
   module GridParser
+    def info : Spatial::Grid::Info
+      nx, ny, nz, bounds = read_header
+      Spatial::Grid::Info.new bounds, {nx, ny, nz}
+    end
+
     private def read_array(nx : Int,
                            ny : Int,
                            nz : Int,

--- a/src/chem/io/parser.cr
+++ b/src/chem/io/parser.cr
@@ -691,6 +691,9 @@ module Chem
     end
   end
 
+  abstract class Spatial::Grid::Parser < IO::Parser(Spatial::Grid)
+  end
+
   macro finished
     {% for parser in IO::Parser.all_subclasses.select(&.annotation(IO::FileType)) %}
       {% format = parser.annotation(IO::FileType)[:format].id.underscore %}

--- a/src/chem/io/parser.cr
+++ b/src/chem/io/parser.cr
@@ -692,6 +692,7 @@ module Chem
   end
 
   abstract class Spatial::Grid::Parser < IO::Parser(Spatial::Grid)
+    abstract def info : Spatial::Grid::Info
   end
 
   macro finished

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -47,6 +47,23 @@ module Chem::Spatial
       grid
     end
 
+    def self.info(path : Path | String) : Info
+      info path, IO::FileFormat.from_ext File.extname(path)
+    end
+
+    def self.info(input : ::IO | Path | String, format : IO::FileFormat) : Info
+      {% begin %}
+        case format
+        {% for parser in Parser.subclasses.select(&.annotation(IO::FileType)) %}
+          when .{{parser.annotation(IO::FileType)[:format].id.underscore.id}}?
+            {{parser}}.new(input).info
+        {% end %}
+        else
+          raise ArgumentError.new "#{format} not supported for Grid"
+        end
+      {% end %}
+    end
+
     def self.new(dim : Dimensions,
                  bounds : Bounds,
                  &block : Int32, Int32, Int32 -> Number)

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -6,6 +6,7 @@ module Chem::Spatial
   class Grid
     alias Dimensions = Tuple(Int32, Int32, Int32)
     alias Index = Tuple(Int32, Int32, Int32)
+    record Info, bounds : Bounds, dim : Dimensions
 
     getter bounds : Bounds
     getter dim : Dimensions


### PR DESCRIPTION
This PR introduces `Grid::Info` that holds grid bounds and points, and `Grid.info` to get the info from files.

Fixes #18 