### PR TITLE
Simplified generation of complementary grids

### DIFF
--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -77,6 +77,22 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe ".fill_like" do
+    it "returns a filled grid with the same bounds and shape of another grid" do
+      grid = Grid.fill_like make_grid(3, 5, 10, Bounds[1.5, 3, 1.3]), 5.0
+      grid.bounds.should eq Bounds[1.5, 3, 1.3]
+      grid.dim.should eq({3, 5, 10})
+      grid.to_a.minmax.should eq({5, 5})
+    end
+
+    it "returns a filled grid with the same bounds and shape of another grid info" do
+      grid = Grid.fill_like Grid::Info.new(Bounds[2, 2, 4], {20, 20, 20}), 23.4
+      grid.bounds.should eq Bounds[2, 2, 4]
+      grid.dim.should eq({20, 20, 20})
+      grid.to_a.minmax.should eq({23.4, 23.4})
+    end
+  end
+
   describe ".new" do
     it "initializes a grid" do
       grid = Grid.new({2, 3, 2}, Bounds[1, 1, 1])

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -61,6 +61,22 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe ".empty_like" do
+    it "returns a zero-filled grid with the same bounds and shape of another grid" do
+      grid = Grid.empty_like make_grid(3, 5, 10, Bounds[1.5, 3, 1.3])
+      grid.bounds.should eq Bounds[1.5, 3, 1.3]
+      grid.dim.should eq({3, 5, 10})
+      grid.to_a.minmax.should eq({0, 0})
+    end
+
+    it "returns a zero-filled grid with the same bounds and shape of another grid info" do
+      grid = Grid.empty_like Grid::Info.new(Bounds[2, 2, 4], {20, 20, 20})
+      grid.bounds.should eq Bounds[2, 2, 4]
+      grid.dim.should eq({20, 20, 20})
+      grid.to_a.minmax.should eq({0, 0})
+    end
+  end
+
   describe ".new" do
     it "initializes a grid" do
       grid = Grid.new({2, 3, 2}, Bounds[1, 1, 1])

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -50,6 +50,19 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe ".atom_distance_like" do
+    it "returns a grid with the same bounds and shape of another grid" do
+      structure = Chem::Structure.build do
+        atom :C, V[1, 0, 0]
+        atom :C, V[0, 0, 1]
+      end
+
+      info = Grid::Info.new Bounds[1.5, 2.135, 6.12], {10, 10, 10}
+      grid = Grid.atom_distance structure, info.dim, info.bounds
+      Grid.atom_distance_like(info, structure).should eq grid
+    end
+  end
+
   describe ".build" do
     it "builds a grid" do
       grid = Grid.build({2, 3, 2}, Bounds.zero) do |buffer|

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -152,6 +152,19 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe ".vdw_mask_like" do
+    it "returns a grid with the same bounds and shape of another grid" do
+      structure = Chem::Structure.build do
+        atom :C, V[1, 0, 0]
+        atom :C, V[0, 0, 1]
+      end
+
+      info = Grid::Info.new Bounds[1.5, 2.135, 6.12], {10, 10, 10}
+      grid = Grid.vdw_mask structure, info.dim, info.bounds
+      Grid.vdw_mask_like(info, structure).should eq grid
+    end
+  end
+
   describe "#==" do
     it "returns true when grids are equal" do
       grid = make_grid(3, 5, 4, Bounds.new(V[0, 1, 3], V[30, 20, 25]))

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -60,6 +60,19 @@ module Chem::Spatial
       new other.dim, other.bounds
     end
 
+    # Returns a grid with the same bounds and points as *other* filled with *value*.
+    #
+    # ```
+    # grid = Grid.from_dx "/path/to/grid"
+    # other = Grid.fill_like grid, 2345.123
+    # other.bounds == grid.bounds # => true
+    # other.dim == grid.dim       # => true
+    # other.to_a.minmax           # => {2345.123, 2345.123}
+    # ```
+    def self.fill_like(other : self | Info, value : Number) : self
+      new other.dim, other.bounds, value.to_f
+    end
+
     def self.info(path : Path | String) : Info
       info path, IO::FileFormat.from_ext File.extname(path)
     end

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -47,6 +47,19 @@ module Chem::Spatial
       grid
     end
 
+    # Returns a zero-filled grid with the same bounds and points as *other*.
+    #
+    # ```
+    # grid = Grid.from_dx "/path/to/grid"
+    # other = Grid.empty_like grid
+    # other.bounds == grid.bounds # => true
+    # other.dim == grid.dim       # => true
+    # other.to_a.minmax           # => {0.0, 0.0}
+    # ```
+    def self.empty_like(other : self | Info) : self
+      new other.dim, other.bounds
+    end
+
     def self.info(path : Path | String) : Info
       info path, IO::FileFormat.from_ext File.extname(path)
     end

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -146,6 +146,21 @@ module Chem::Spatial
       grid
     end
 
+    # Returns a grid mask with the points at the vdW spheres set to 1. It will have the
+    # same bounds and points as *other*.
+    #
+    # ```
+    # structure = Structure.read "path/to/file"
+    # info = Grid::Info.new Bounds[5.213, 6.823, 10.352], {20, 25, 40}
+    # grid = Grid.vdw_mask structure, info.dim, info.bounds
+    # Grid.vdw_mask_like(info, structure) == grid # => true
+    # ```
+    def self.vdw_mask_like(other : self | Info,
+                           structure : Structure,
+                           delta : Float64 = 0.02) : self
+      vdw_mask structure, other.dim, other.bounds, delta
+    end
+
     def ==(rhs : self) : Bool
       return false unless @dim == rhs.dim && @bounds == rhs.bounds
       size.times do |i|

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -39,6 +39,19 @@ module Chem::Spatial
       end
     end
 
+    # Returns a grid filled with the distances to the nearest atom. It will have the
+    # same bounds and points as *other*.
+    #
+    # ```
+    # structure = Structure.read "path/to/file"
+    # info = Grid::Info.new Bounds[1.5, 2.135, 6.12], {10, 10, 10}
+    # grid = Grid.atom_distance structure, info.dim, info.bounds
+    # Grid.atom_distance_like(info, structure) == grid # => true
+    # ```
+    def self.atom_distance_like(other : self | Info, structure : Structure) : self
+      atom_distance structure, other.dim, other.bounds
+    end
+
     def self.build(dim : Dimensions,
                    bounds : Bounds,
                    &block : Pointer(Float64) ->)


### PR DESCRIPTION
This PR makes working with grids easier, particularly when creating a complementary grid to an existing one, e.g., grid arithmetic, grid masks, etc. This PR also introduces the ability to read a grid file header to avoid loading an entire grid just to extract its shape and bounds (hold in a `Grid::Info` instance), which is ideal to be used with `*_like` methods.

The methods in question are:

* `.atom_distance_like`
* `.empty_like`
* `.fill_like`
* `.info`
* `.vdw_mask_like`