### PR TITLE
Input/output methods now accept positional args

### DIFF
--- a/spec/io/vasp/chgcar_spec.cr
+++ b/spec/io/vasp/chgcar_spec.cr
@@ -18,7 +18,7 @@ describe Chem::VASP::Chgcar do
   end
 
   it "writes a CHGCAR" do
-    st = Chem::Structure.build(guess_topology: false) do
+    structure = Chem::Structure.build(guess_topology: false) do
       title "NaCl-O-NaCl"
       lattice 5, 10, 20
       atom :Cl, V[30, 15, 10]
@@ -29,7 +29,7 @@ describe Chem::VASP::Chgcar do
     end
 
     grid = make_grid(3, 3, 3, Bounds[5, 10, 20]) { |i, j, k| i * 100 + j * 10 + k }
-    grid.to_chgcar(structure: st).should eq <<-EOF
+    grid.to_chgcar(structure).should eq <<-EOF
       NaCl-O-NaCl
          1.00000000000000
            5.0000000000000000    0.0000000000000000    0.0000000000000000
@@ -58,14 +58,14 @@ describe Chem::VASP::Chgcar do
   it "fails when writing a CHGCAR with a non-periodic structure" do
     grid = make_grid 3, 3, 3, Bounds.zero
     expect_raises Chem::Spatial::NotPeriodicError do
-      grid.to_chgcar structure: Chem::Structure.new
+      grid.to_chgcar Chem::Structure.new
     end
   end
 
   it "fails when lattice and bounds are incompatible" do
     structure = Chem::Structure.build { lattice 10, 20, 30 }
     expect_raises ArgumentError, "Incompatible structure and grid" do
-      make_grid(3, 3, 3, Bounds[20, 20, 20]).to_chgcar structure: structure
+      make_grid(3, 3, 3, Bounds[20, 20, 20]).to_chgcar structure
     end
   end
 end

--- a/spec/io/vasp/locpot_spec.cr
+++ b/spec/io/vasp/locpot_spec.cr
@@ -19,7 +19,7 @@ describe Chem::VASP::Locpot do
   end
 
   it "writes a LOCPOT" do
-    st = Chem::Structure.build(guess_topology: false) do
+    structure = Chem::Structure.build(guess_topology: false) do
       title "NaCl-O-NaCl"
       lattice 5, 10, 20
       atom :Cl, V[30, 15, 10]
@@ -30,7 +30,7 @@ describe Chem::VASP::Locpot do
     end
 
     grid = make_grid(3, 3, 3, Bounds[5, 10, 20]) { |i, j, k| i * 100 + j * 10 + k }
-    grid.to_locpot(structure: st).should eq <<-EOF
+    grid.to_locpot(structure).should eq <<-EOF
       NaCl-O-NaCl
          1.00000000000000
            5.0000000000000000    0.0000000000000000    0.0000000000000000
@@ -44,7 +44,7 @@ describe Chem::VASP::Locpot do
          10.0000000000000000    5.0000000000000000    5.0000000000000000
          10.0000000000000000   10.0000000000000000   12.5000000000000000
          30.0000000000000000   15.0000000000000000    9.0000000000000000
-      
+
           3    3    3
        0.00000000000E+00 1.00000000000E+02 2.00000000000E+02 1.00000000000E+01 1.10000000000E+02
        2.10000000000E+02 2.00000000000E+01 1.20000000000E+02 2.20000000000E+02 1.00000000000E+00
@@ -59,14 +59,14 @@ describe Chem::VASP::Locpot do
   it "fails when writing a LOCPOT with a non-periodic structure" do
     grid = make_grid 3, 3, 3, Bounds.zero
     expect_raises Chem::Spatial::NotPeriodicError do
-      grid.to_locpot structure: Chem::Structure.new
+      grid.to_locpot Chem::Structure.new
     end
   end
 
   it "fails when lattice and bounds are incompatible" do
     structure = Chem::Structure.build { lattice 10, 20, 30 }
     expect_raises ArgumentError, "Incompatible structure and grid" do
-      make_grid(3, 3, 3, Bounds[20, 20, 20]).to_locpot structure: structure
+      make_grid(3, 3, 3, Bounds[20, 20, 20]).to_locpot structure
     end
   end
 end

--- a/src/chem/io/formats/dftb/gen.cr
+++ b/src/chem/io/formats/dftb/gen.cr
@@ -3,8 +3,9 @@ module Chem::DFTB::Gen
   class Writer < IO::Writer(AtomCollection)
     def initialize(output : ::IO | Path | String,
                    @fractional : Bool = false,
+                   *,
                    sync_close : Bool = false)
-      super output, sync_close
+      super output, sync_close: sync_close
     end
 
     def write(atoms : AtomCollection, lattice : Lattice? = nil) : Nil

--- a/src/chem/io/formats/pdb.cr
+++ b/src/chem/io/formats/pdb.cr
@@ -68,8 +68,9 @@ module Chem::PDB
     def initialize(io : ::IO | Path | String,
                    @bonds : Bool | Array(Bond) = false,
                    @renumber : Bool = true,
+                   *,
                    sync_close : Bool = false)
-      super io, sync_close
+      super io, sync_close: sync_close
     end
 
     def close : Nil

--- a/src/chem/io/formats/vasp/poscar.cr
+++ b/src/chem/io/formats/vasp/poscar.cr
@@ -4,9 +4,10 @@ module Chem::VASP::Poscar
     def initialize(io : ::IO | Path | String,
                    order @ele_order : Array(Element)? = nil,
                    @fractional : Bool = false,
-                   sync_close : Bool = false,
-                   @wrap : Bool = false)
-      super io, sync_close
+                   @wrap : Bool = false,
+                   *,
+                   sync_close : Bool = false)
+      super io, sync_close: sync_close
     end
 
     def write(atoms : AtomCollection, lattice : Lattice? = nil, title : String = "") : Nil

--- a/src/chem/io/formats/vasp/utils.cr
+++ b/src/chem/io/formats/vasp/utils.cr
@@ -49,8 +49,9 @@ module Chem::VASP
 
     def initialize(input : ::IO | Path | String,
                    @structure : Structure,
+                   *,
                    sync_close : Bool = false)
-      super input
+      super input, sync_close: sync_close
     end
 
     private def incompatible_expcetion : Nil

--- a/src/chem/io/parser.cr
+++ b/src/chem/io/parser.cr
@@ -704,21 +704,22 @@ module Chem
       {% keyword = type < Reference ? "class" : "struct" unless keyword %}
 
       {{keyword.id}} ::{{type.id}}
-        def self.from_{{format.id}}(input : ::IO | Path | String, **options) : self
-          {{parser}}.new(input, **options).parse
+        def self.from_{{format.id}}(input : ::IO | Path | String, *args, **options) : self
+          {{parser}}.new(input, *args, **options).parse
         end
       end
 
       class ::Array(T)
-        def self.from_{{format.id}}(input : ::IO | Path | String, **options) : self
-          {{parser}}.new(input, **options).to_a
+        def self.from_{{format.id}}(input : ::IO | Path | String, *args, **options) : self
+          {{parser}}.new(input, *args, **options).to_a
         end
 
         def self.from_{{format.id}}(input : ::IO | Path | String,
                                     indexes : Array(Int),
+                                    *args,
                                     **options) : self
           ary = Array(Chem::Structure).new indexes.size
-          {{parser}}.new(input, **options).each(indexes) { |st| ary << st }
+          {{parser}}.new(input, *args, **options).each(indexes) { |st| ary << st }
           ary
         end
       end

--- a/src/chem/io/writer.cr
+++ b/src/chem/io/writer.cr
@@ -7,7 +7,7 @@ module Chem
 
     @io : ::IO
 
-    def initialize(input : ::IO | Path | String, @sync_close : Bool = false)
+    def initialize(input : ::IO | Path | String, *, @sync_close : Bool = false)
       if input.is_a?(Path | String)
         input = File.new(input, "w")
         @sync_close = true
@@ -15,8 +15,8 @@ module Chem
       @io = input
     end
 
-    def self.open(io : ::IO | Path | String, sync_close : Bool = false, **options)
-      writer = new io, **options, sync_close: sync_close
+    def self.open(io : ::IO | Path | String, *args, sync_close : Bool = false, **options)
+      writer = new io, *args, **options, sync_close: sync_close
       yield writer ensure writer.close
     end
 
@@ -50,14 +50,14 @@ module Chem
       {% keyword = type < Reference ? "class" : "struct" unless keyword %}
 
       {{keyword.id}} ::{{type.id}}
-        def to_{{format.id}}(**options) : String
+        def to_{{format.id}}(*args, **options) : String
           String.build do |io|
-            to_{{format.id}} io, **options
+            to_{{format.id}} io, *args, **options
           end
         end
 
-        def to_{{format.id}}(output : ::IO | Path | String, **options) : Nil
-          {{writer}}.open(output, **options) do |writer|
+        def to_{{format.id}}(output : ::IO | Path | String, *args, **options) : Nil
+          {{writer}}.open(output, *args, **options) do |writer|
             writer.write self
           end
         end


### PR DESCRIPTION
`#from_*` and `#to_*` methods allowed for named arguments only. Now they accept positional arguments, which required to set `sync_close` option in `Writer` as named argument. This helps usability of parsers/writers that have additional required arguments, e.g.,

```
# before
grid.to_dx
grid.to_cube atoms: structure
grid.to_chgcar structure: structure

# after
grid.to_dx
grid.to_cube structure
grid.to_chgcar structure
```