### PR TITLE
File formats can now match filenames

### DIFF
--- a/spec/io/file_format_spec.cr
+++ b/spec/io/file_format_spec.cr
@@ -40,6 +40,29 @@ describe Chem::IO::FileFormat do
     end
   end
 
+  describe ".from_filename" do
+    it "fails for unknown filename" do
+      expect_raises ArgumentError, "File format not found for foo.bar" do
+        Chem::IO::FileFormat.from_filename "foo.bar"
+      end
+    end
+  end
+
+  describe ".from_filename?" do
+    it "returns file format based on filename" do
+      Chem::IO::FileFormat.from_filename?("img.tiff").should eq Chem::IO::FileFormat::Image
+      Chem::IO::FileFormat.from_filename?("spec.cad").should eq Chem::IO::FileFormat::CAD
+      Chem::IO::FileFormat.from_filename?("spec").should eq Chem::IO::FileFormat::License
+      Chem::IO::FileFormat.from_filename?("license").should eq Chem::IO::FileFormat::License
+      Chem::IO::FileFormat.from_filename?("license.key").should eq Chem::IO::FileFormat::License
+    end
+
+    it "returns nil for unknown filename" do
+      Chem::IO::FileFormat.from_filename?("foo.bar").should be_nil
+      Chem::IO::FileFormat.from_filename?("baz").should be_nil
+    end
+  end
+
   describe ".from_stem" do
     it "fails for unknown file stem" do
       expect_raises ArgumentError, "File format not found for UNKNOWN" do

--- a/spec/io/file_format_spec.cr
+++ b/spec/io/file_format_spec.cr
@@ -1,13 +1,13 @@
 require "../spec_helper"
 
-@[Chem::IO::FileType(format: CAD, ext: [:cad])]
+@[Chem::IO::FileType(format: CAD, ext: %w(cad))]
 class CAD::Parser < Chem::IO::Parser(String)
   def parse : String
     "foo"
   end
 end
 
-@[Chem::IO::FileType(format: Image, ext: [:bmp, :jpg, :png, :tiff])]
+@[Chem::IO::FileType(format: Image, ext: %w(bmp jpg png tiff))]
 class Image::Writer < Chem::IO::Writer(String)
   def write(obj : String) : Nil; end
 end

--- a/spec/io/file_format_spec.cr
+++ b/spec/io/file_format_spec.cr
@@ -34,7 +34,7 @@ describe Chem::IO::FileFormat do
 
   describe ".from_ext" do
     it "fails for unknown file extension" do
-      expect_raises Exception, "Unknown file extension: .hei" do
+      expect_raises ArgumentError, "File format not found for .hei" do
         Chem::IO::FileFormat.from_ext ".hei"
       end
     end

--- a/spec/io/file_format_spec.cr
+++ b/spec/io/file_format_spec.cr
@@ -12,6 +12,11 @@ class Image::Writer < Chem::IO::Writer(String)
   def write(obj : String) : Nil; end
 end
 
+@[Chem::IO::FileType(format: License, ext: %w(lic), names: %w(SPEC LIC* *KE *any*))]
+class License::Writer < Chem::IO::Writer(String)
+  def write(obj : String) : Nil; end
+end
+
 describe Chem::IO::FileFormat do
   describe ".from_ext?" do
     it "returns file format based on file extension" do
@@ -31,6 +36,28 @@ describe Chem::IO::FileFormat do
     it "fails for unknown file extension" do
       expect_raises Exception, "Unknown file extension: .hei" do
         Chem::IO::FileFormat.from_ext ".hei"
+      end
+    end
+  end
+
+  describe ".from_stem" do
+    it "fails for unknown file stem" do
+      expect_raises ArgumentError, "File format not found for UNKNOWN" do
+        Chem::IO::FileFormat.from_stem "UNKNOWN"
+      end
+    end
+  end
+
+  describe ".from_stem?" do
+    it "returns file format based on file stem" do
+      %w(SPEC Spec spec LIC LICENSE LICENSE_MIT KE NAM_KE ANY AMANYLOC).each do |stem|
+        Chem::IO::FileFormat.from_stem?(stem).should eq Chem::IO::FileFormat::License
+      end
+    end
+
+    it "returns nil for unknown file stem" do
+      %w(Specs LIKENSE NOTLIC KENOT KE_NOT UNKNOWN).each do |stem|
+        Chem::IO::FileFormat.from_stem?(stem).should be_nil
       end
     end
   end

--- a/spec/io/file_format_spec.cr
+++ b/spec/io/file_format_spec.cr
@@ -24,7 +24,9 @@ describe Chem::IO::FileFormat do
       Chem::IO::FileFormat.from_ext?(".jpg").should eq Chem::IO::FileFormat::Image
       Chem::IO::FileFormat.from_ext?(".png").should eq Chem::IO::FileFormat::Image
       Chem::IO::FileFormat.from_ext?(".tiff").should eq Chem::IO::FileFormat::Image
+      Chem::IO::FileFormat.from_ext?(".TIFF").should eq Chem::IO::FileFormat::Image
       Chem::IO::FileFormat.from_ext?(".cad").should eq Chem::IO::FileFormat::CAD
+      Chem::IO::FileFormat.from_ext?(".CAD").should eq Chem::IO::FileFormat::CAD
     end
 
     it "returns nil for unknown file extension" do

--- a/spec/io/writer_spec.cr
+++ b/spec/io/writer_spec.cr
@@ -20,7 +20,7 @@ describe Chem::IO::Writer do
   end
 end
 
-@[Chem::IO::FileType(format: Document, ext: [:pdf, :doc, :docx, :rtf])]
+@[Chem::IO::FileType(format: Document, ext: %w(pdf doc docx rtf))]
 class Document::Writer < Chem::IO::Writer(String)
   def write(obj : String) : Nil
     @io << '<' << obj << '>'

--- a/src/chem/core/structure.cr
+++ b/src/chem/core/structure.cr
@@ -22,7 +22,7 @@ module Chem
     end
 
     def self.read(path : Path | String, guess_topology : Bool = true) : self
-      format = IO::FileFormat.from_ext File.extname(path)
+      format = IO::FileFormat.from_filename File.basename(path)
       read path, format, guess_topology
     end
 

--- a/src/chem/io/formats.cr
+++ b/src/chem/io/formats.cr
@@ -1,6 +1,20 @@
 module Chem::IO
-  # format : String
-  # ext : Array(Tuple(String, Symbol))
+  # Marks a class as a provider of a file format.
+  #
+  # A file type associates extensions and/or file names with a file format, and links
+  # the latter to the annotated classes. If the file format does not exist, it is
+  # registered.
+  #
+  # This annotation accepts the file format (required), and either an array of
+  # extensions (without leading dot) or an array of file names, or both. File names can
+  # include wildcards (*) to denote either prefix (e.g., "Foo*"), suffix (e.g., "*Bar"),
+  # or both (e.g., "*Baz*").
+  #
+  # ```
+  # @[FileType(format: Log, ext: %w(txt log out), names: %w(LOG *OUT))]
+  # class LogParser
+  # end
+  # ```
   annotation FileType; end
 
   macro finished

--- a/src/chem/io/formats.cr
+++ b/src/chem/io/formats.cr
@@ -59,7 +59,7 @@ module Chem::IO
 
       def self.from_ext?(extname : String) : self?
         {% begin %}
-          case extname
+          case extname.downcase
           {% for format in file_formats %}
             {% extensions = [] of MacroId %}
             {% for file_type in file_types.select(&.[:format].id.==(format)) %}
@@ -67,7 +67,7 @@ module Chem::IO
                 {% extensions << ext %}
               {% end %}
             {% end %}
-            when {{extensions.uniq.map { |ext| ".#{ext.id}" }.splat}}
+            when {{extensions.uniq.map { |ext| ".#{ext.downcase.id}" }.splat}}
               {{format}}
           {% end %}
           else

--- a/src/chem/io/formats.cr
+++ b/src/chem/io/formats.cr
@@ -115,11 +115,11 @@ module Chem::IO
       # ...
       #
       # FileFormat.from_filename("IMG_2314.tiff") # => FileFormat::Image
-      # FileFormat.from_filename("IMG_2314.png") # => FileFormat::Image
-      # FileFormat.from_filename("IMG_2314") # => FileFormat::Image
-      # FileFormat.from_filename("img_2314") # => FileFormat::Image
-      # FileFormat.from_filename("img2314") # => FileFormat::Image
-      # FileFormat.from_filename("Imi") # => raises ArgumentError
+      # FileFormat.from_filename("IMG_2314.png")  # => FileFormat::Image
+      # FileFormat.from_filename("IMG_2314")      # => FileFormat::Image
+      # FileFormat.from_filename("img_2314")      # => FileFormat::Image
+      # FileFormat.from_filename("img2314")       # => FileFormat::Image
+      # FileFormat.from_filename("Imi")           # => raises ArgumentError
       # ```
       def self.from_filename(filename : Path | String) : self
         format = from_filename? filename
@@ -137,11 +137,11 @@ module Chem::IO
       # ...
       #
       # FileFormat.from_filename?("IMG_2314.tiff") # => FileFormat::Image
-      # FileFormat.from_filename?("IMG_2314.png") # => FileFormat::Image
-      # FileFormat.from_filename?("IMG_2314") # => FileFormat::Image
-      # FileFormat.from_filename?("img_2314") # => FileFormat::Image
-      # FileFormat.from_filename?("img2314") # => FileFormat::Image
-      # FileFormat.from_filename?("Imi") # => nil
+      # FileFormat.from_filename?("IMG_2314.png")  # => FileFormat::Image
+      # FileFormat.from_filename?("IMG_2314")      # => FileFormat::Image
+      # FileFormat.from_filename?("img_2314")      # => FileFormat::Image
+      # FileFormat.from_filename?("img2314")       # => FileFormat::Image
+      # FileFormat.from_filename?("Imi")           # => nil
       # ```
       def self.from_filename?(filename : Path | String) : self?
         filename = Path[filename] unless filename.is_a?(Path)
@@ -162,8 +162,8 @@ module Chem::IO
       #
       # FileFormat.from_stem("IMG_2314") # => FileFormat::Image
       # FileFormat.from_stem("img_2314") # => FileFormat::Image
-      # FileFormat.from_stem("img2314") # => FileFormat::Image
-      # FileFormat.from_stem("Imi") # => raises ArgumentError
+      # FileFormat.from_stem("img2314")  # => FileFormat::Image
+      # FileFormat.from_stem("Imi")      # => raises ArgumentError
       # ```
       def self.from_stem(stem : Path | String) : self
         from_stem?(stem) || raise ArgumentError.new "File format not found for #{stem}"
@@ -181,8 +181,8 @@ module Chem::IO
       #
       # FileFormat.from_stem?("IMG_2314") # => FileFormat::Image
       # FileFormat.from_stem?("img_2314") # => FileFormat::Image
-      # FileFormat.from_stem?("img2314") # => FileFormat::Image
-      # FileFormat.from_stem?("Imi") # => nil
+      # FileFormat.from_stem?("img2314")  # => FileFormat::Image
+      # FileFormat.from_stem?("Imi")      # => nil
       # ```
       def self.from_stem?(stem : String) : self?
         stem = stem.camelcase.downcase

--- a/src/chem/io/formats.cr
+++ b/src/chem/io/formats.cr
@@ -76,6 +76,52 @@ module Chem::IO
         {% end %}
       end
 
+      # Returns the file format associated with *filename*, or raises `ArgumentError`
+      # otherwise.
+      #
+      # It first looks up the file format associated with the extension in *filename*
+      # via `.from_ext?`. If this yields no result, then it executes a case-insensitive
+      # search with the stem in *filename* via `.from_stem?`.
+      #
+      # ```
+      # @[FileType(format: Image, ext: %w(tiff png jpg), names: %w(IMG*))]
+      # ...
+      #
+      # FileFormat.from_filename("IMG_2314.tiff") # => FileFormat::Image
+      # FileFormat.from_filename("IMG_2314.png") # => FileFormat::Image
+      # FileFormat.from_filename("IMG_2314") # => FileFormat::Image
+      # FileFormat.from_filename("img_2314") # => FileFormat::Image
+      # FileFormat.from_filename("img2314") # => FileFormat::Image
+      # FileFormat.from_filename("Imi") # => raises ArgumentError
+      # ```
+      def self.from_filename(filename : Path | String) : self
+        format = from_filename? filename
+        format || raise ArgumentError.new "File format not found for #{filename}"
+      end
+
+      # Returns the file format associated with *filename*, or `nil` otherwise.
+      #
+      # It first looks up the file format associated with the extension in *filename*
+      # via `.from_ext?`. If this yields no result, then it executes a case-insensitive
+      # search with the stem in *filename* via `.from_stem?`.
+      #
+      # ```
+      # @[FileType(format: Image, ext: %w(tiff png jpg), names: %w(IMG*))]
+      # ...
+      #
+      # FileFormat.from_filename?("IMG_2314.tiff") # => FileFormat::Image
+      # FileFormat.from_filename?("IMG_2314.png") # => FileFormat::Image
+      # FileFormat.from_filename?("IMG_2314") # => FileFormat::Image
+      # FileFormat.from_filename?("img_2314") # => FileFormat::Image
+      # FileFormat.from_filename?("img2314") # => FileFormat::Image
+      # FileFormat.from_filename?("Imi") # => nil
+      # ```
+      def self.from_filename?(filename : Path | String) : self?
+        filename = Path[filename] unless filename.is_a?(Path)
+        extname = filename.extension
+        from_ext?(extname) || from_stem?(filename.basename(extname))
+      end
+
       # Returns the file format associated with *stem*, or raises `ArgumentError`
       # otherwise.
       #

--- a/src/chem/io/formats.cr
+++ b/src/chem/io/formats.cr
@@ -53,10 +53,37 @@ module Chem::IO
         {{format.id}}
       {% end %}
 
+      # Returns the file format associated with *extname*, or raises `ArgumentError`
+      # otherwise.
+      #
+      # ```
+      # @[FileType(format: Image, ext: %w(tiff png jpg))]
+      # ...
+      #
+      # FileFormat.from_ext("img.tiff") # => FileFormat::Image
+      # FileFormat.from_ext("img.TIFF") # => FileFormat::Image
+      # FileFormat.from_ext("img.png")  # => FileFormat::Image
+      # FileFormat.from_ext("img.txt")  # => raises ArgumentError
+      # ```
+      #
+      # NOTE: it performs a case-insensitive search so .tiff and .TIFF return the same.
       def self.from_ext(extname : String) : self
         from_ext?(extname) || raise ArgumentError.new "File format not found for #{extname}"
       end
 
+      # Returns the file format associated with *extname*, or `nil` otherwise.
+      #
+      # ```
+      # @[FileType(format: Image, ext: %w(tiff png jpg))]
+      # ...
+      #
+      # FileFormat.from_ext?("img.tiff") # => FileFormat::Image
+      # FileFormat.from_ext?("img.TIFF") # => FileFormat::Image
+      # FileFormat.from_ext?("img.png")  # => FileFormat::Image
+      # FileFormat.from_ext?("img.txt")  # => nil
+      # ```
+      #
+      # NOTE: it performs a case-insensitive search so .tiff and .TIFF return the same.
       def self.from_ext?(extname : String) : self?
         {% begin %}
           case extname.downcase

--- a/src/chem/io/formats.cr
+++ b/src/chem/io/formats.cr
@@ -32,6 +32,8 @@ module Chem::IO
       # check duplicate file extensions (different file formats)
       {% format_by_ext = {} of String => MacroId %}
       {% klass_by_ext = {} of String => MacroId %}
+      {% format_by_name = {} of String => MacroId %}
+      {% klass_by_name = {} of String => MacroId %}
       {% for klass in klasses %}
         {% format = klass.annotation(IO::FileType)[:format].id %}
         {% if extnames = klass.annotation(IO::FileType)[:ext] %}
@@ -45,6 +47,17 @@ module Chem::IO
             {% klass_by_ext[ext] = klass %}
           {% end %}
         {% end %}
+
+        {% if names = klass.annotation(IO::FileType)[:names] %}
+          {% for name in names %}
+            {% key = name.tr("*", "").camelcase.underscore %}
+            {% if (other = format_by_name[key]) && other != format %}
+              {% klass.raise "File name #{name} declared in #{klass} is already " \
+                             "associated with file format #{other} via " \
+                             "#{klass_by_name[name]}" %}
+            {% end %}
+            {% format_by_name[key] = format %}
+            {% klass_by_name[key] = klass %}
           {% end %}
         {% end %}
       {% end %}

--- a/src/chem/io/formats.cr
+++ b/src/chem/io/formats.cr
@@ -54,7 +54,7 @@ module Chem::IO
       {% end %}
 
       def self.from_ext(extname : String) : self
-        from_ext?(extname) || raise "Unknown file extension: #{extname}"
+        from_ext?(extname) || raise ArgumentError.new "File format not found for #{extname}"
       end
 
       def self.from_ext?(extname : String) : self?

--- a/src/chem/io/formats.cr
+++ b/src/chem/io/formats.cr
@@ -14,6 +14,8 @@ module Chem::IO
       {% for klass in klasses %}
         {% t = klass.annotation(FileType) %}
         {% klass.raise "FileType annotation on #{klass} must set `format`" unless t[:format] %}
+        {% if !t[:ext] && !t[:names] %}
+          {% klass.raise "FileType annotation on #{klass} must set either `ext` or `names`" %}
         {% end %}
       {% end %}
 

--- a/src/chem/io/formats/dftb/gen.cr
+++ b/src/chem/io/formats/dftb/gen.cr
@@ -1,5 +1,5 @@
 module Chem::DFTB::Gen
-  @[IO::FileType(format: Gen, ext: [:gen])]
+  @[IO::FileType(format: Gen, ext: %w(gen))]
   class Writer < IO::Writer(AtomCollection)
     def initialize(output : ::IO | Path | String,
                    @fractional : Bool = false,
@@ -40,7 +40,7 @@ module Chem::DFTB::Gen
     end
   end
 
-  @[IO::FileType(format: Gen, ext: [:gen])]
+  @[IO::FileType(format: Gen, ext: %w(gen))]
   class Parser < Structure::Parser
     include IO::PullParser
 

--- a/src/chem/io/formats/dx.cr
+++ b/src/chem/io/formats/dx.cr
@@ -1,5 +1,5 @@
 module Chem::DX
-  @[IO::FileType(format: DX, ext: [:dx])]
+  @[IO::FileType(format: DX, ext: %w(dx))]
   class Parser < Spatial::Grid::Parser
     include IO::AsciiParser
 
@@ -43,7 +43,7 @@ module Chem::DX
     end
   end
 
-  @[IO::FileType(format: DX, ext: [:dx])]
+  @[IO::FileType(format: DX, ext: %w(dx))]
   class Writer < IO::Writer(Spatial::Grid)
     def write(grid : Spatial::Grid) : Nil
       check_open

--- a/src/chem/io/formats/mol2.cr
+++ b/src/chem/io/formats/mol2.cr
@@ -5,7 +5,7 @@ module Chem::Mol2
     Bond
   end
 
-  @[IO::FileType(format: Mol2, ext: [:mol2])]
+  @[IO::FileType(format: Mol2, ext: %w(mol2))]
   class Writer < IO::Writer(AtomCollection)
     @atom_table = {} of Atom => Int32
     @res_table = {} of Residue => Int32
@@ -97,7 +97,7 @@ module Chem::Mol2
     end
   end
 
-  @[IO::FileType(format: Mol2, ext: [:mol2])]
+  @[IO::FileType(format: Mol2, ext: %w(mol2))]
   class Parser < Structure::Parser
     include IO::PullParser
 

--- a/src/chem/io/formats/pdb.cr
+++ b/src/chem/io/formats/pdb.cr
@@ -55,7 +55,7 @@ module Chem::PDB
     end
   end
 
-  @[IO::FileType(format: PDB, ext: [:pdb])]
+  @[IO::FileType(format: PDB, ext: %w(ent pdb))]
   class Writer < IO::Writer(AtomCollection)
     PDB_VERSION      = "3.30"
     PDB_VERSION_DATE = Time.local 2011, 7, 13
@@ -226,7 +226,7 @@ module Chem::PDB
     end
   end
 
-  @[IO::FileType(format: PDB, ext: [:ent, :pdb])]
+  @[IO::FileType(format: PDB, ext: %w(ent pdb))]
   class Parser < Structure::Parser
     include IO::ColumnBasedParser
 

--- a/src/chem/io/formats/vasp/chgcar.cr
+++ b/src/chem/io/formats/vasp/chgcar.cr
@@ -1,5 +1,5 @@
 module Chem::VASP::Chgcar
-  @[IO::FileType(format: Chgcar, ext: [:chgcar])]
+  @[IO::FileType(format: Chgcar, names: %w(CHGCAR*))]
   class Parser < Spatial::Grid::Parser
     include IO::AsciiParser
     include VASP::GridParser
@@ -11,7 +11,7 @@ module Chem::VASP::Chgcar
     end
   end
 
-  @[IO::FileType(format: Chgcar, ext: [:chgcar])]
+  @[IO::FileType(format: Chgcar, names: %w(CHGCAR*))]
   class Writer < IO::Writer(Spatial::Grid)
     include VASP::GridWriter
 

--- a/src/chem/io/formats/vasp/locpot.cr
+++ b/src/chem/io/formats/vasp/locpot.cr
@@ -1,5 +1,5 @@
 module Chem::VASP::Locpot
-  @[IO::FileType(format: Locpot, ext: [:locpot])]
+  @[IO::FileType(format: Locpot, names: %w(LOCPOT*))]
   class Parser < Spatial::Grid::Parser
     include IO::AsciiParser
     include GridParser
@@ -10,7 +10,7 @@ module Chem::VASP::Locpot
     end
   end
 
-  @[IO::FileType(format: Locpot, ext: [:locpot])]
+  @[IO::FileType(format: Locpot, names: %w(LOCPOT*))]
   class Writer < IO::Writer(Spatial::Grid)
     include GridWriter
 

--- a/src/chem/io/formats/vasp/poscar.cr
+++ b/src/chem/io/formats/vasp/poscar.cr
@@ -1,5 +1,5 @@
 module Chem::VASP::Poscar
-  @[IO::FileType(format: Poscar, ext: [:poscar])]
+  @[IO::FileType(format: Poscar, ext: %w(poscar), names: %w(POSCAR* CONTCAR*))]
   class Writer < IO::Writer(AtomCollection)
     def initialize(io : ::IO | Path | String,
                    order @ele_order : Array(Element)? = nil,
@@ -76,7 +76,7 @@ module Chem::VASP::Poscar
     end
   end
 
-  @[IO::FileType(format: Poscar, ext: [:poscar])]
+  @[IO::FileType(format: Poscar, names: %w(POSCAR* CONTCAR*))]
   class Parser < Structure::Parser
     include IO::PullParser
 

--- a/src/chem/io/formats/xyz.cr
+++ b/src/chem/io/formats/xyz.cr
@@ -1,5 +1,5 @@
 module Chem::XYZ
-  @[IO::FileType(format: XYZ, ext: [:xyz])]
+  @[IO::FileType(format: XYZ, ext: %w(xyz))]
   class Writer < IO::Writer(AtomCollection)
     def write(atoms : AtomCollection, title : String = "") : Nil
       check_open
@@ -16,7 +16,7 @@ module Chem::XYZ
     end
   end
 
-  @[IO::FileType(format: XYZ, ext: [:xyz])]
+  @[IO::FileType(format: XYZ, ext: %w(xyz))]
   class Parser < Structure::Parser
     include IO::PullParser
 

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -87,7 +87,7 @@ module Chem::Spatial
     end
 
     def self.info(path : Path | String) : Info
-      info path, IO::FileFormat.from_ext File.extname(path)
+      info path, IO::FileFormat.from_filename File.basename(path)
     end
 
     def self.info(input : ::IO | Path | String, format : IO::FileFormat) : Info


### PR DESCRIPTION
This PR adds support for associating file names to a file format along with file extensions. It also includes minor tweaks and add docs.

There are several examples where the file name (without extension) dictates the file format, e.g., VASP-related files like POSCAR, CHGCAR, etc., so parsers/writers were updated as well.