### PR TITLE
Simplified grid parsers by using Grid::Info

### DIFF
--- a/src/chem/io/formats/cube.cr
+++ b/src/chem/io/formats/cube.cr
@@ -20,9 +20,8 @@ module Chem::Cube
     end
 
     def parse : Spatial::Grid
-      grid_info = info
-      Spatial::Grid.build(grid_info.dim, grid_info.bounds) do |buffer|
-        (grid_info.dim[0] * grid_info.dim[1] * grid_info.dim[2]).times do |i|
+      Spatial::Grid.build(info) do |buffer, size|
+        size.times do |i|
           buffer[i] = read_float
         end
       end

--- a/src/chem/io/formats/dx.cr
+++ b/src/chem/io/formats/dx.cr
@@ -5,35 +5,28 @@ module Chem::DX
 
     def info : Spatial::Grid::Info
       skip_comments
-      dim, bounds = read_header
-      Spatial::Grid::Info.new bounds, dim
-    end
-
-    def parse : Spatial::Grid
-      skip_comments
-      dim, bounds = read_header
-      Spatial::Grid.build(dim, bounds) do |buffer|
-        (dim[0] * dim[1] * dim[2]).times do |i|
-          buffer[i] = read_float
-        end
-      end
-    end
-
-    private def read_header : Tuple(Spatial::Grid::Dimensions, Bounds)
       skip_words 5
       nx, ny, nz = read_int, read_int, read_int
       skip_word # origin
       origin = read_vector
       skip_word # delta
-      a = read_vector
+      i = read_vector
       skip_word # delta
-      b = read_vector
+      j = read_vector
       skip_word # delta
-      c = read_vector
+      k = read_vector
       skip_lines 3
 
-      size = Spatial::Size[a.size * (nx - 1), b.size * (ny - 1), c.size * (nz - 1)]
-      { {nx, ny, nz}, Bounds.new(origin, size) }
+      size = Spatial::Size[i.size * (nx - 1), j.size * (ny - 1), k.size * (nz - 1)]
+      Spatial::Grid::Info.new Spatial::Bounds.new(origin, size), {nx, ny, nz}
+    end
+
+    def parse : Spatial::Grid
+      Spatial::Grid.build(info) do |buffer, size|
+        size.times do |i|
+          buffer[i] = read_float
+        end
+      end
     end
 
     private def skip_comments : Nil

--- a/src/chem/io/formats/vasp/chgcar.cr
+++ b/src/chem/io/formats/vasp/chgcar.cr
@@ -5,9 +5,9 @@ module Chem::VASP::Chgcar
     include VASP::GridParser
 
     def parse : Spatial::Grid
-      nx, ny, nz, bounds = read_header
-      volume = bounds.volume
-      read_array nx, ny, nz, bounds, &./(volume)
+      info = self.info
+      volume = info.bounds.volume
+      read_array info, &./(volume)
     end
   end
 

--- a/src/chem/io/formats/vasp/locpot.cr
+++ b/src/chem/io/formats/vasp/locpot.cr
@@ -5,8 +5,8 @@ module Chem::VASP::Locpot
     include GridParser
 
     def parse : Spatial::Grid
-      nx, ny, nz, bounds = read_header
-      read_array nx, ny, nz, bounds, &.itself
+      info = self.info
+      read_array info, &.itself
     end
   end
 

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -52,6 +52,24 @@ module Chem::Spatial
       atom_distance structure, other.dim, other.bounds
     end
 
+    # Creates a new `Grid` with *info* and yields a buffer to be filled.
+    #
+    # This method is **unsafe**, but it is usually used to initialize the buffer in a
+    # linear fashion, e.g., reading values from a file.
+    #
+    # ```
+    # Grid.build(Grid.info("/path/to/file")) do |buffer, size|
+    #   size.times do |i|
+    #     buffer[i] = read_value
+    #   end
+    # end
+    # ```
+    def self.build(info : Info, & : Pointer(Float64), Int32 ->) : self
+      grid = empty_like info
+      yield grid.to_unsafe, grid.size
+      grid
+    end
+
     def self.build(dim : Dimensions,
                    bounds : Bounds,
                    &block : Pointer(Float64) ->)

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -72,9 +72,9 @@ module Chem::Spatial
 
     def self.build(dim : Dimensions,
                    bounds : Bounds,
-                   &block : Pointer(Float64) ->)
+                   &block : Pointer(Float64), Int32 ->) : self
       grid = new dim, bounds
-      yield grid.to_unsafe
+      yield grid.to_unsafe, grid.size
       grid
     end
 


### PR DESCRIPTION
Grid parsers were refactored to have a single method, `#info`, that reads file header, and `#parse` to use the former to build a new grid (via the new `Grid#build(Grid::Info)` method)