### PR TITLE
Minor tweak to VASP grid parsers

### DIFF
--- a/src/chem/io/formats/vasp/utils.cr
+++ b/src/chem/io/formats/vasp/utils.cr
@@ -14,11 +14,12 @@ module Chem::VASP
     private def read_array(info : Spatial::Grid::Info,
                            & : Float64 -> Float64) : Spatial::Grid
       nx, ny, nz = info.dim
+      nyz = ny * nz
       Grid.build(info) do |buffer|
         nz.times do |k|
           ny.times do |j|
             nx.times do |i|
-              buffer[i * ny * nz + j * nz + k] = yield read_float
+              buffer[i * nyz + j * nz + k] = yield read_float
             end
           end
         end


### PR DESCRIPTION
`ny * nz` is now cached in VASP grid parse code, which is needed to calculate the correct index; VASP grid files are in the order Z-Y-X (fastest is last) instead of X-Y-Z.

It improves performance slightly, which will be significant for large files.