### PR TITLE
Support for non-orthogonal grids

### DIFF
--- a/spec/io/cube_spec.cr
+++ b/spec/io/cube_spec.cr
@@ -18,6 +18,29 @@ describe Chem::Cube::Parser do
     info.bounds.size.should be_close S[12.184834, 12.859271, 13.117308], 1e-6
   end
 
+  it "parses a cube file header (non-orthogonal)" do
+    io = IO::Memory.new <<-EOS
+      Comment line 1
+      Comment line 2
+         3   -7.230385   -7.775379  -12.555472
+        14    1.146929    0.000000    0.000000
+        20    0.255354    1.061993    0.000000
+        22    0.499640    0.190885    3.536519
+        29   29.000000    2.317035    3.509540   -0.795570
+         8    8.000000    3.517299    6.882575   -1.794666
+         1    1.000000    3.658572    8.310089   -0.667807
+         1    1.000000    3.557810    7.487509   -3.515277
+      EOS
+    info = Grid.info io, :cube
+    info.dim.should eq({14, 20, 22})
+    info.bounds.should be_close Bounds.new(
+      V[-3.826155, -4.114553, -6.64407],
+      V[8.497002, 0.0, 0.0],
+      V[2.702550, 11.23965, 0.0],
+      V[5.816758, 2.222264, 41.171796],
+    ), 1e-6
+  end
+
   it "fails when cube have multiple densities" do
     io = IO::Memory.new <<-EOF
       CPMD CUBE FILE.

--- a/spec/io/dx_spec.cr
+++ b/spec/io/dx_spec.cr
@@ -37,8 +37,8 @@ describe Chem::DX::Parser do
       object 1 class gridpositions counts 2 3 3
       origin   0.500   0.300   1.000
       delta   10.000   0.000   0.000
-      delta    0.000  20.000   0.000
-      delta    0.000   0.000  10.000
+      delta    5.000  20.000   0.000
+      delta    8.000   5.000  10.000
       object 2 class gridconnections counts 2 3 3
       object 3 class array type double rank 0 items 18 data follows
             0.00000000      1.00000000      2.00000000
@@ -49,7 +49,12 @@ describe Chem::DX::Parser do
           120.00000000    121.00000000    122.00000000\n
       EOS
     info = Grid.info io, :dx
-    info.bounds.should eq Bounds.new(V[0.5, 0.3, 1], S[10, 40, 20])
+    info.bounds.should eq Bounds.new(
+      V[0.5, 0.3, 1],
+      V[10, 0, 0],
+      V[10, 40, 0],
+      V[16, 10, 20]
+    )
     info.dim.should eq({2, 3, 3})
   end
 end

--- a/spec/io/vasp/locpot_spec.cr
+++ b/spec/io/vasp/locpot_spec.cr
@@ -4,7 +4,12 @@ describe Chem::VASP::Locpot do
   it "parses a LOCPOT" do
     grid = Grid.from_locpot "spec/data/vasp/LOCPOT"
     grid.dim.should eq({32, 32, 32})
-    grid.bounds.should be_close Bounds[2.969, 2.969, 2.969], 1e-3
+    grid.bounds.should be_close Bounds.new(
+      V.origin,
+      V[2.969072, -0.000523, -0.000907],
+      V[-0.987305, 2.800110, 0.000907],
+      V[-0.987305, -1.402326, 2.423654],
+    ), 1e-6
     grid[0, 0, 0].should eq -46.16312251
     grid[0, 5, 11].should eq -8.1037443195
     grid[7, 31, 0].should eq -17.403441349
@@ -14,7 +19,12 @@ describe Chem::VASP::Locpot do
 
   it "parses a LOCPOT header" do
     info = Grid.info "spec/data/vasp/LOCPOT", :chgcar
-    info.bounds.should be_close Bounds[2.969, 2.969, 2.969], 1e-3
+    info.bounds.should be_close Bounds.new(
+      V.origin,
+      V[2.969072, -0.000523, -0.000907],
+      V[-0.987305, 2.800110, 0.000907],
+      V[-0.987305, -1.402326, 2.423654],
+    ), 1e-6
     info.dim.should eq({32, 32, 32})
   end
 

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -226,15 +226,16 @@ describe Chem::Spatial::Grid do
     end
 
     it "returns the value at the coordinates" do
-      grid = make_grid 6, 10, 8, Bounds.new(V[2, 3, 4], S[1, 1, 1])
+      grid = make_grid 6, 11, 9, Bounds.new(V[2, 3, 4], S[1, 1, 1])
       grid[V[2, 3, 4]]?.should eq 0
-      grid[V[2.5, 3.5, 4.5]]?.should eq 195
-      grid[V[3, 4, 5]]?.should eq 479
+      grid[V[2.2, 3.6, 4.25]]?.should eq 155
+      grid[V[3, 4, 5]]?.should eq 593
     end
 
     it "returns the value close to the coordinates" do
       grid = make_grid 6, 10, 8, Bounds.new(V[2, 3, 4], S[1, 1, 1])
-      grid[V[2.51, 3.505, 4.51]]?.should eq 195 # no interpolation
+      grid[V[2.51, 3.505, 4.51]]?.should eq 284 # no interpolation
+      grid[V[2.65, 3.24, 4.97]]?.should eq 263  # no interpolation
     end
 
     it "returns nil when indexes are out of bounds" do
@@ -270,6 +271,13 @@ describe Chem::Spatial::Grid do
       grid.coords_at?(0, 0, 0).should eq V[1, 2, 3]
       grid.coords_at?(10, 10, 10).should eq V[11, 22, 33]
       grid.coords_at?(3, 5, 0).should eq V[4, 12, 3]
+    end
+
+    it "returns the coordinates at indexes (non-orthogonal)" do
+      grid = make_grid 11, 11, 11, Bounds.new(V[1, 2, 3], S[10, 10, 5], 90, 90, 120)
+      grid.coords_at?(0, 0, 0).should eq V[1, 2, 3]
+      grid.coords_at?(10, 10, 10).not_nil!.should be_close V[6, 10.660, 8], 1e-3
+      grid.coords_at?(3, 5, 0).not_nil!.should be_close V[1.5, 6.330, 3], 1e-3
     end
 
     it "returns nil when indexes are out of bounds" do
@@ -374,7 +382,16 @@ describe Chem::Spatial::Grid do
       grid = make_grid 6, 10, 8, Bounds.new(V[2, 3, 4], S[1, 1, 1])
       grid.index(V[2, 3, 4]).should eq({0, 0, 0})
       grid.index(V[3, 4, 5]).should eq({5, 9, 7})
-      grid.index(V[2.5, 3.5, 4.5]).should eq({2, 4, 3})
+      grid.index(V[2.45, 3.4, 4.4]).should eq({2, 4, 3})
+      grid.index(V[2.16, 3.75, 4.87]).should eq({1, 7, 6})
+    end
+
+    it "returns the index at the coordinates (non-orthogonal)" do
+      grid = make_grid 11, 11, 11, Bounds.new(V[4, 3, 2], S[5, 5, 4], 90, 100, 90)
+      grid.index(V[4, 3, 2]).should eq({0, 0, 0})
+      grid.index(V[8.305, 8, 5.939]).should eq({10, 10, 10})
+      grid.index(V[4.5, 6.21, 2.63]).should eq({1, 6, 2})
+      grid.index(V[7.4, 4.91, 5.4]).should eq({8, 4, 9})
     end
 
     it "returns nil when coordinates are out of bounds" do

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -110,9 +110,9 @@ describe Chem::Spatial::Grid do
     it "initializes a grid" do
       grid = Grid.new({2, 3, 2}, Bounds[1, 1, 1])
       grid.dim.should eq({2, 3, 2})
-      grid.nx.should eq 2
-      grid.ny.should eq 3
-      grid.nz.should eq 2
+      grid.ni.should eq 2
+      grid.nj.should eq 3
+      grid.nk.should eq 2
       grid.resolution.should eq({1, 0.5, 1})
       grid.to_a.should eq Array(Float64).new(12, 0.0)
     end
@@ -460,21 +460,21 @@ describe Chem::Spatial::Grid do
     end
   end
 
-  describe "#nx" do
+  describe "#ni" do
     it "returns the number of points along the first axis" do
-      make_grid(2, 6, 1).nx.should eq 2
+      make_grid(2, 6, 1).ni.should eq 2
     end
   end
 
-  describe "#ny" do
+  describe "#nj" do
     it "returns the number of points along the second axis" do
-      make_grid(2, 6, 1).ny.should eq 6
+      make_grid(2, 6, 1).nj.should eq 6
     end
   end
 
-  describe "#nz" do
+  describe "#nk" do
     it "returns the number of points along the third axis" do
-      make_grid(2, 6, 1).nz.should eq 1
+      make_grid(2, 6, 1).nk.should eq 1
     end
   end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -90,9 +90,9 @@ module Spec
 
     def match(actual_value : Chem::Spatial::Bounds) : Bool
       (actual_value.origin - @expected_value.origin).abs.size <= @delta &&
-        (actual_value.size.x - @expected_value.size.x).abs <= @delta &&
-        (actual_value.size.y - @expected_value.size.y).abs <= @delta &&
-        (actual_value.size.z - @expected_value.size.z).abs <= @delta
+        (actual_value.i - @expected_value.i).abs.size <= @delta &&
+        (actual_value.j - @expected_value.j).abs.size <= @delta &&
+        (actual_value.k - @expected_value.k).abs.size <= @delta
     end
   end
 end

--- a/src/chem/io/formats/cube.cr
+++ b/src/chem/io/formats/cube.cr
@@ -68,9 +68,9 @@ module Chem::Cube
 
     private def write_header(grid : Spatial::Grid) : Nil
       origin = grid.origin * ANGS_TO_BOHR
-      i = grid.bounds.i / grid.nx * ANGS_TO_BOHR
-      j = grid.bounds.j / grid.ny * ANGS_TO_BOHR
-      k = grid.bounds.k / grid.nz * ANGS_TO_BOHR
+      i = grid.bounds.i / grid.ni * ANGS_TO_BOHR
+      j = grid.bounds.j / grid.nj * ANGS_TO_BOHR
+      k = grid.bounds.k / grid.nk * ANGS_TO_BOHR
 
       @io.puts "CUBE FILE GENERATED WITH CHEM.CR"
       @io.puts "OUTER LOOP: X, MIDDLE LOOP: Y, INNER LOOP: Z"

--- a/src/chem/io/formats/dx.cr
+++ b/src/chem/io/formats/dx.cr
@@ -57,13 +57,13 @@ module Chem::DX
     end
 
     private def write_connections(grid : Spatial::Grid) : Nil
-      formatl "object 2 class gridconnections counts %d %d %d", grid.nx, grid.ny, grid.nz
+      formatl "object 2 class gridconnections counts %d %d %d", grid.ni, grid.nj, grid.nk
     end
 
     private def write_header(grid : Spatial::Grid) : Nil
       rx, ry, rz = grid.resolution
 
-      formatl "object 1 class gridpositions counts %d %d %d", grid.nx, grid.ny, grid.nz
+      formatl "object 1 class gridpositions counts %d %d %d", grid.ni, grid.nj, grid.nk
       formatl "origin%8.3f%8.3f%8.3f", grid.origin.x, grid.origin.y, grid.origin.z
       formatl "delta %8.3f%8.3f%8.3f", rx, 0, 0
       formatl "delta %8.3f%8.3f%8.3f", 0, ry, 0

--- a/src/chem/io/formats/dx.cr
+++ b/src/chem/io/formats/dx.cr
@@ -6,19 +6,19 @@ module Chem::DX
     def info : Spatial::Grid::Info
       skip_comments
       skip_words 5
-      nx, ny, nz = read_int, read_int, read_int
+      ni, nj, nk = read_int, read_int, read_int
       skip_word # origin
       origin = read_vector
       skip_word # delta
-      i = read_vector
+      i = read_vector * (ni - 1)
       skip_word # delta
-      j = read_vector
+      j = read_vector * (nj - 1)
       skip_word # delta
-      k = read_vector
+      k = read_vector * (nk - 1)
       skip_lines 3
 
-      size = Spatial::Size[i.size * (nx - 1), j.size * (ny - 1), k.size * (nz - 1)]
-      Spatial::Grid::Info.new Spatial::Bounds.new(origin, size), {nx, ny, nz}
+      bounds = Spatial::Bounds.new origin, i, j, k
+      Spatial::Grid::Info.new bounds, {ni, nj, nk}
     end
 
     def parse : Spatial::Grid

--- a/src/chem/io/formats/vasp/utils.cr
+++ b/src/chem/io/formats/vasp/utils.cr
@@ -3,11 +3,11 @@ module Chem::VASP
     def info : Spatial::Grid::Info
       skip_line
       scale = read_float
-      lattice = Lattice.new scale * read_vector, scale * read_vector, scale * read_vector
+      i, j, k = scale * read_vector, scale * read_vector, scale * read_vector
       skip_atoms
       nx, ny, nz = read_int, read_int, read_int
 
-      bounds = Spatial::Bounds.new Spatial::Vector.origin, lattice.size
+      bounds = Spatial::Bounds.new Spatial::Vector.origin, i, j, k
       Spatial::Grid::Info.new bounds, {nx, ny, nz}
     end
 

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -304,11 +304,8 @@ module Chem::Spatial
 
     def index(vec : Vector) : Index?
       return unless bounds.includes? vec
-      rx, ry, rz = resolution
-      i = ((vec.x - origin.x) / rx).to_i
-      j = ((vec.y - origin.y) / ry).to_i
-      k = ((vec.z - origin.z) / rz).to_i
-      {i, j, k}
+      vec = (vec - origin).to_fractional bounds.basis
+      (vec * @dim.map &.-(1)).round.to_t.map &.to_i
     end
 
     def index!(vec : Vector) : Index
@@ -361,9 +358,9 @@ module Chem::Spatial
     {% end %}
 
     def resolution : Tuple(Float64, Float64, Float64)
-      {nx == 1 ? 0.0 : bounds.size.x / (nx - 1),
-       ny == 1 ? 0.0 : bounds.size.y / (ny - 1),
-       nz == 1 ? 0.0 : bounds.size.z / (nz - 1)}
+      {nx == 1 ? 0.0 : bounds.i.size / (nx - 1),
+       ny == 1 ? 0.0 : bounds.j.size / (ny - 1),
+       nz == 1 ? 0.0 : bounds.k.size / (nz - 1)}
     end
 
     def size : Int32
@@ -428,8 +425,10 @@ module Chem::Spatial
 
     @[AlwaysInline]
     private def unsafe_coords_at(i : Int, j : Int, k : Int) : Vector
-      rx, ry, rz = resolution
-      Vector[origin.x + i * rx, origin.y + j * ry, origin.z + k * rz]
+      vi = nx == 1 ? Vector.zero : bounds.i / (nx - 1)
+      vj = ny == 1 ? Vector.zero : bounds.j / (ny - 1)
+      vk = nz == 1 ? Vector.zero : bounds.k / (nz - 1)
+      origin + i * vi + j * vj + k * vk
     end
 
     @[AlwaysInline]


### PR DESCRIPTION
This PR adds support for non-cubic volumes, that is, accounts for non-orthogonal axis vectors during both parsing and coordinates calculation.