### PR TITLE
Grid masking

### DIFF
--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -480,6 +480,26 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe "#mask!" do
+    it "masks a grid in-place by a number" do
+      grid = make_grid(2, 3, 2) { |i, j, k| i + j + k }
+      grid.mask! 3
+      grid.to_a.should eq [0, 0, 0, 0, 0, 3, 0, 0, 0, 3, 3, 0]
+    end
+
+    it "masks a grid in-place by a range" do
+      grid = make_grid(2, 3, 2) { |i, j, k| (i + 1) * (j + 1) * (k + 1) }
+      grid.mask! 3..10
+      grid.to_a.should eq [0, 0, 0, 4, 3, 6, 0, 4, 4, 8, 6, 0]
+    end
+
+    it "masks a grid in-place with a block" do
+      grid = make_grid(2, 3, 2) { |i, j, k| (i + 1) * (j + 1) * (k + 1) }
+      grid.mask! &.>(4.1)
+      grid.to_a.should eq [0, 0, 0, 0, 0, 6, 0, 0, 0, 8, 6, 12]
+    end
+  end
+
   describe "#ni" do
     it "returns the number of points along the first axis" do
       make_grid(2, 6, 1).ni.should eq 2

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -467,6 +467,12 @@ describe Chem::Spatial::Grid do
       grid.to_a.should eq [0, 1, 1, 2, 1, 2, 2, 3]
     end
 
+    it "returns a masked grid by a number+-delta" do
+      grid = make_grid(2, 2, 3) { |i, j, k| (i + 1) * (j + 1) * (k + 1) / 5 }
+      grid.mask(1, 0.5).to_a.should eq [0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 0]
+      grid.to_a.should eq [0.2, 0.4, 0.6, 0.4, 0.8, 1.2, 0.4, 0.8, 1.2, 0.8, 1.6, 2.4]
+    end
+
     it "returns a masked grid by a range" do
       grid = make_grid(2, 2, 3) { |i, j, k| (i + 1) * (j + 1) * (k + 1) }
       grid.mask(2..4.5).to_a.should eq [0, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0]
@@ -485,6 +491,12 @@ describe Chem::Spatial::Grid do
       grid = make_grid(2, 3, 2) { |i, j, k| i + j + k }
       grid.mask! 3
       grid.to_a.should eq [0, 0, 0, 0, 0, 3, 0, 0, 0, 3, 3, 0]
+    end
+
+    it "masks a grid in-place by a number+-delta" do
+      grid = make_grid(2, 2, 3) { |i, j, k| (i + j + k) / 5 }
+      grid.mask! 0.5, 0.1
+      grid.to_a.should eq [0, 0, 0.4, 0, 0.4, 0.6, 0, 0.4, 0.6, 0.4, 0.6, 0]
     end
 
     it "masks a grid in-place by a range" do

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -460,6 +460,26 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe "#mask" do
+    it "returns a masked grid by a number" do
+      grid = make_grid(2, 2, 2) { |i, j, k| i + j + k }
+      grid.mask(2).to_a.should eq [0, 0, 0, 1, 0, 1, 1, 0]
+      grid.to_a.should eq [0, 1, 1, 2, 1, 2, 2, 3]
+    end
+
+    it "returns a masked grid by a range" do
+      grid = make_grid(2, 2, 3) { |i, j, k| (i + 1) * (j + 1) * (k + 1) }
+      grid.mask(2..4.5).to_a.should eq [0, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0]
+      grid.to_a.should eq [1, 2, 3, 2, 4, 6, 2, 4, 6, 4, 8, 12]
+    end
+
+    it "returns a masked grid with a block" do
+      grid = make_grid(2, 2, 3) { |i, j, k| (i + 1) / (j + 1) * (k + 1) }
+      grid.mask(&.<(2)).to_a.should eq [1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0]
+      grid.to_a.should eq [1, 2, 3, 0.5, 1, 1.5, 2, 4, 6, 1, 2, 3]
+    end
+  end
+
   describe "#ni" do
     it "returns the number of points along the first axis" do
       make_grid(2, 6, 1).ni.should eq 2

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -512,6 +512,22 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe "#mask_by_index" do
+    it "returns a grid mask" do
+      grid = make_grid(2, 2, 2)
+      grid.mask_by_index { |i, j, k| k == 1 }.to_a.should eq [0, 1, 0, 1, 0, 1, 0, 1]
+      grid.to_a.should eq [0, 1, 2, 3, 4, 5, 6, 7]
+    end
+  end
+
+  describe "#mask_by_index!" do
+    it "masks a grid in-place by index" do
+      grid = make_grid(2, 2, 2)
+      grid.mask_by_index! { |i, j, k| i == 1 }
+      grid.to_a.should eq [0, 0, 0, 0, 4, 5, 6, 7]
+    end
+  end
+
   describe "#ni" do
     it "returns the number of points along the first axis" do
       make_grid(2, 6, 1).ni.should eq 2

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -512,6 +512,22 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe "#mask_by_coords" do
+    it "returns a grid mask" do
+      grid = make_grid(2, 2, 2, Bounds[1, 1, 1])
+      grid.mask_by_coords(&.x.==(0)).to_a.should eq [1, 1, 1, 1, 0, 0, 0, 0]
+      grid.to_a.should eq [0, 1, 2, 3, 4, 5, 6, 7]
+    end
+  end
+
+  describe "#mask_by_coords!" do
+    it "masks a grid in-place by coordinates" do
+      grid = make_grid(2, 2, 2, Bounds[5, 5, 5])
+      grid.mask_by_coords! { |vec| vec.y == 5 }
+      grid.to_a.should eq [0, 0, 2, 3, 0, 0, 6, 7]
+    end
+  end
+
   describe "#mask_by_index" do
     it "returns a grid mask" do
       grid = make_grid(2, 2, 2)

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -383,6 +383,22 @@ module Chem::Spatial
       mask { |ele| pattern === ele }
     end
 
+    # Returns a grid mask. Elements for which `(value - ele).abs <= delta` returns
+    # `true` are set to 1, otherwise 0.
+    #
+    # Grid masks are very useful to deal with multiple grids, and when points are to be
+    # selected based on one grid only.
+    #
+    # ```
+    # grid = Grid.new({2, 2, 3}, Bounds[1, 1, 1]) { |i, j, k| (i + 1) * (j + 1) * (k + 1) / 5 }
+    # grid.to_a              # => [0.2, 0.4, 0.6, 0.4, 0.8, 1.2, 0.4, 0.8, 1.2, 0.8, 1.6, 2.4]
+    # grid.mask(1, 0.5).to_a # => [0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 0]
+    # grid.to_a              # => [0.2, 0.4, 0.6, 0.4, 0.8, 1.2, 0.4, 0.8, 1.2, 0.8, 1.6, 2.4]
+    # ```
+    def mask(value : Number, delta : Number) : self
+      mask (value - delta)..(value + delta)
+    end
+
     # Masks a grid by the passed block. Elements for which the passed block returns
     # `false` are set to 0.
     #
@@ -413,6 +429,22 @@ module Chem::Spatial
     # ```
     def mask!(pattern) : self
       mask! { |ele| pattern === ele }
+    end
+
+    # Masks a grid by *value*+/-*delta*. Elements for which `(value - ele).abs > delta`
+    # returns `true` are set to 0.
+    #
+    # Optimized version for creating a mask and applying it to the same grid, i.e.,
+    # `grid * grid.mask(value, delta)`, by avoiding creation of intermediate grids.
+    #
+    # ```
+    # grid = Grid.new({2, 2, 3}, Bounds[1, 1, 1]) { |i, j, k| (i + j + k) / 5 }
+    # grid.to_a # => [0.0, 0.2, 0.4, 0.2, 0.4, 0.6, 0.2, 0.4, 0.6, 0.4, 0.6, 0.8]
+    # grid.mask! 0.5, 0.1
+    # grid.to_a # => [0.0, 0.0, 0.4, 0.0, 0.4, 0.6, 0.0, 0.4, 0.6, 0.4, 0.6, 0.0]
+    # ```
+    def mask!(value : Number, delta : Number) : self
+      mask! (value - delta)..(value + delta)
     end
 
     def ni : Int32

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -450,6 +450,39 @@ module Chem::Spatial
       mask! (value - delta)..(value + delta)
     end
 
+    # Returns a grid mask. Coordinates for which the passed block returns `true` are set
+    # to 1, otherwise 0.
+    #
+    # Grid masks are very useful to deal with multiple grids, and when points are to be
+    # selected based on one grid only.
+    #
+    # ```
+    # grid = Grid.new({2, 2, 2}, Bounds[10, 10, 10]) { |i, j, k| i * 4 + j * 2 + k }
+    # grid.to_a                           # => [0, 1, 2, 3, 4, 5, 6, 7]
+    # grid.mask_by_coords(&.x.==(0)).to_a # => [1, 1, 1, 1, 0, 0, 0, 0]
+    # grid.to_a                           # => [0, 1, 2, 3, 4, 5, 6, 7]
+    # ```
+    def mask_by_coords(& : Vector -> Bool) : self
+      map_with_coords { |_, vec| (yield vec) ? 1.0 : 0.0 }
+    end
+
+    # Masks a grid by coordinates. Coordinates for which the passed block returns
+    # `false` are set to 0.
+    #
+    # Optimized version of creating a mask and applying it to the same grid, but avoids
+    # creating intermediate grids. This is equivalent to `grid = grid *
+    # grid.mask_by_coords { ... }`
+    #
+    # ```
+    # grid = Grid.new({2, 2, 2}, Bounds[5, 5, 5]) { |i, j, k| i * 4 + j * 2 + k }
+    # grid.to_a # => [0, 1, 2, 3, 4, 5, 6, 7]
+    # grid.mask_by_coords! { |vec| vec.y == 5 }
+    # grid.to_a # => [0, 0, 2, 3, 0, 0, 6, 7]
+    # ```
+    def mask_by_coords!(& : Vector -> Bool) : self
+      map_with_coords! { |ele, vec| (yield vec) ? ele : 0.0 }
+    end
+
     # Returns a grid mask. Indexes for which the passed block returns `true` are set to
     # 1, otherwise 0.
     #

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -351,6 +351,38 @@ module Chem::Spatial
       self
     end
 
+    # Returns a grid mask. Elements for which the passed block returns `true` are set to
+    # 1, otherwise 0.
+    #
+    # Grid masks are very useful to deal with multiple grids, and when points are to be
+    # selected based on one grid only.
+    #
+    # ```
+    # grid = Grid.new({2, 2, 2}, Bounds[10, 10, 10]) { |i, j, k| i + j + k }
+    # grid.to_a              # => [0, 1, 1, 2, 1, 2, 2, 3]
+    # grid.mask(&.>(1)).to_a # => [0, 0, 0, 1, 0, 1, 1, 1]
+    # grid.to_a              # => [0, 1, 1, 2, 1, 2, 2, 3]
+    # ```
+    def mask(& : Float64 -> Bool) : self
+      map { |ele| (yield ele) ? 1.0 : 0.0 }
+    end
+
+    # Returns a grid mask. Elements for which `pattern === element` returns `true` are
+    # set to 1, otherwise 0.
+    #
+    # Grid masks are very useful to deal with multiple grids, and when points are to be
+    # selected based on one grid only.
+    #
+    # ```
+    # grid = Grid.new({2, 2, 3}, Bounds[1, 1, 1]) { |i, j, k| (i + 1) * (j + 1) * (k + 1) }
+    # grid.to_a              # => [1, 2, 3, 2, 4, 6, 2, 4, 6, 4, 8, 12]
+    # grid.mask(2..4.5).to_a # => [0, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0]
+    # grid.to_a              # => [1, 2, 3, 2, 4, 6, 2, 4, 6, 4, 8, 12]
+    # ```
+    def mask(pattern) : self
+      mask { |ele| pattern === ele }
+    end
+
     def ni : Int32
       dim[0]
     end

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -402,8 +402,9 @@ module Chem::Spatial
     # Masks a grid by the passed block. Elements for which the passed block returns
     # `false` are set to 0.
     #
-    # Optimized version for creating a mask and apply it to the same grid, i.e., `grid *
-    # grid.mask { ... }`, by avoiding creation of intermediate grids.
+    # Optimized version of creating a mask and applying it to the same grid, but avoids
+    # creating intermediate grids. This is equivalent to `grid = grid * grid.mask
+    # { ... }`.
     #
     # ```
     # grid = Grid.new({2, 2, 2}, Bounds[10, 10, 10]) { |i, j, k| i + j + k }
@@ -418,8 +419,9 @@ module Chem::Spatial
     # Masks a grid by *pattern*. Elements for which `pattern === element` returns
     # `false` are set to 0.
     #
-    # Optimized version for creating a mask and apply it to the same grid, i.e., `grid *
-    # grid.mask(*pattern*)`, by avoiding creation of intermediate grids.
+    # Optimized version of creating a mask and applying it to the same grid, but avoids
+    # creating intermediate grids. This is equivalent to `grid = grid *
+    # grid.mask(pattern)`
     #
     # ```
     # grid = Grid.new({2, 2, 3}, Bounds[1, 1, 1]) { |i, j, k| (i + 1) * (j + 1) * (k + 1) }
@@ -434,8 +436,9 @@ module Chem::Spatial
     # Masks a grid by *value*+/-*delta*. Elements for which `(value - ele).abs > delta`
     # returns `true` are set to 0.
     #
-    # Optimized version for creating a mask and applying it to the same grid, i.e.,
-    # `grid * grid.mask(value, delta)`, by avoiding creation of intermediate grids.
+    # Optimized version of creating a mask and applying it to the same grid, but avoids
+    # creating intermediate grids. This is equivalent to `grid = grid * grid.mask(value,
+    # delta)`
     #
     # ```
     # grid = Grid.new({2, 2, 3}, Bounds[1, 1, 1]) { |i, j, k| (i + j + k) / 5 }

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -450,6 +450,39 @@ module Chem::Spatial
       mask! (value - delta)..(value + delta)
     end
 
+    # Returns a grid mask. Indexes for which the passed block returns `true` are set to
+    # 1, otherwise 0.
+    #
+    # Grid masks are very useful to deal with multiple grids, and when points are to be
+    # selected based on one grid only.
+    #
+    # ```
+    # grid = Grid.new({2, 2, 2}, Bounds[10, 10, 10]) { |i, j, k| i * 4 + j * 2 + k }
+    # grid.to_a                                    # => [0, 1, 2, 3, 4, 5, 6, 7]
+    # grid.mask_by_index { |i, j, k| k == 1 }.to_a # => [0, 1, 0, 1, 0, 1, 0, 1]
+    # grid.to_a                                    # => [0, 1, 2, 3, 4, 5, 6, 7]
+    # ```
+    def mask_by_index(& : Int32, Int32, Int32 -> Bool) : self
+      map_with_index { |_, i, j, k| (yield i, j, k) ? 1.0 : 0.0 }
+    end
+
+    # Masks a grid by index. Indexes for which the passed block returns `false` are set
+    # to 0.
+    #
+    # Optimized version of creating a mask and applying it to the same grid, but avoids
+    # creating intermediate grids. This is equivalent to `grid = grid *
+    # grid.mask_by_index { ... }`
+    #
+    # ```
+    # grid = Grid.new({2, 2, 2}, Bounds[1, 1, 1]) { |i, j, k| i * 4 + j * 2 + k }
+    # grid.to_a # => [0, 1, 2, 3, 4, 5, 6, 7]
+    # grid.mask_by_index! { |i, j, k| i == 1 }
+    # grid.to_a # => [0, 0, 0, 0, 4, 5, 6, 7]
+    # ```
+    def mask_by_index!(& : Int32, Int32, Int32 -> Bool) : self
+      map_with_index! { |ele, i, j, k| (yield i, j, k) ? ele : 0.0 }
+    end
+
     def ni : Int32
       dim[0]
     end

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -383,6 +383,38 @@ module Chem::Spatial
       mask { |ele| pattern === ele }
     end
 
+    # Masks a grid by the passed block. Elements for which the passed block returns
+    # `false` are set to 0.
+    #
+    # Optimized version for creating a mask and apply it to the same grid, i.e., `grid *
+    # grid.mask { ... }`, by avoiding creation of intermediate grids.
+    #
+    # ```
+    # grid = Grid.new({2, 2, 2}, Bounds[10, 10, 10]) { |i, j, k| i + j + k }
+    # grid.to_a # => [0, 1, 1, 2, 1, 2, 2, 3]
+    # grid.mask! &.>(1)
+    # grid.to_a # => [0, 0, 0, 2, 0, 2, 2, 3]
+    # ```
+    def mask!(& : Float64 -> Bool) : self
+      map! { |ele| (yield ele) ? ele : 0.0 }
+    end
+
+    # Masks a grid by *pattern*. Elements for which `pattern === element` returns
+    # `false` are set to 0.
+    #
+    # Optimized version for creating a mask and apply it to the same grid, i.e., `grid *
+    # grid.mask(*pattern*)`, by avoiding creation of intermediate grids.
+    #
+    # ```
+    # grid = Grid.new({2, 2, 3}, Bounds[1, 1, 1]) { |i, j, k| (i + 1) * (j + 1) * (k + 1) }
+    # grid.to_a # => [1, 2, 3, 2, 4, 6, 2, 4, 6, 4, 8, 12]
+    # grid.mask! 2..4.5
+    # grid.to_a # => [0, 2, 3, 2, 4, 0, 2, 4, 0, 4, 0, 0]
+    # ```
+    def mask!(pattern) : self
+      mask! { |ele| pattern === ele }
+    end
+
     def ni : Int32
       dim[0]
     end


### PR DESCRIPTION
This PR adds several methods to handle grid masking.

A grid mask is a grid where each value is either 0 or 1, which can then be used to select certain points of another grid by right multiplication, *masked_A = A * mask*. For instance, to calculate the average value of the electrostatic potential (ESP) at the molecular surface, one first creates a mask by selecting the points with a value around 0.001 a.u. in a electron density grid, then multiply a ESP grid by it to "turn off" undesired points, and finally compute the average of the masked ESP grid.