### PR TITLE
Added Grid#mean methods

### DIFF
--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -712,6 +712,18 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe "#mean_with_coords" do
+    it "returns the arithmetic mean along an axis with its coordinates" do
+      ary = make_grid(2, 3, 11, Bounds[4, 5, 6]).mean_with_coords(axis: 2)
+      ary.map(&.[0]).should eq [
+        27.5, 28.5, 29.5, 30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5,
+      ]
+      ary.map(&.[1]).should be_close [
+        0, 0.6, 1.2, 1.8, 2.4, 3, 3.6, 4.2, 4.8, 5.4, 6,
+      ], 1e-15
+    end
+  end
+
   describe "#min" do
     it "returns the minimum value" do
       ((make_grid(2, 3, 2) - 5) * 25).min.should eq -125

--- a/spec/spatial/grid_spec.cr
+++ b/spec/spatial/grid_spec.cr
@@ -696,6 +696,22 @@ describe Chem::Spatial::Grid do
     end
   end
 
+  describe "#mean" do
+    it "returns the arithmetic mean" do
+      make_grid(2, 3, 4).mean.should eq 11.5
+    end
+
+    it "returns the arithmetic mean along an axis" do
+      make_grid(2, 3, 4).mean(axis: 0).should eq [5.5, 17.5]
+      make_grid(2, 3, 4).mean(axis: 1).should eq [7.5, 11.5, 15.5]
+      make_grid(2, 3, 4).mean(axis: 2).should eq [10, 11, 12, 13]
+    end
+
+    it "fails when axis is out of bounds" do
+      expect_raises(IndexError) { make_grid(2, 2, 2).mean(axis: 4) }
+    end
+  end
+
   describe "#min" do
     it "returns the minimum value" do
       ((make_grid(2, 3, 2) - 5) * 25).min.should eq -125

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -682,6 +682,27 @@ module Chem::Spatial
       values
     end
 
+    # Returns the arithmetic mean along *axis* with its coordinates.
+    # Axis is specified as an integer: 0-2 refer to the direction of the
+    # first, second or third basis vector, respectively.
+    #
+    # Raises IndexError is *axis* is out of bounds.
+    #
+    # ```
+    # grid = Grid.new({2, 3, 5}, Bounds[1, 1, 1]) { |i, j, k| i * 12 + j * 4 + k }
+    # grid.mean(axis: 1) # => [{9.5, 0.0}, {14.5, 0.5}, {19.5, 1.0}]
+    # ```
+    def mean_with_coords(axis : Int) : Array(Tuple(Float64, Float64))
+      delta = resolution[axis]
+      i = 0
+      ary = Array(Tuple(Float64, Float64)).new @dim[axis]
+      each_axial_slice(axis, reuse: true) do |slice|
+        ary << {slice.sum / slice.size, i * delta}
+        i += 1
+      end
+      ary
+    end
+
     def ni : Int32
       dim[0]
     end

--- a/src/chem/spatial/grid.cr
+++ b/src/chem/spatial/grid.cr
@@ -651,6 +651,37 @@ module Chem::Spatial
       map_with_loc! { |ele, loc| (yield loc) ? ele : 0.0 }
     end
 
+    # Returns the arithmetic mean of the grid elements.
+    #
+    # ```
+    # grid = Grid.new({2, 3, 4}, Bounds[1, 1, 1]) { |i, j, k| i * 12 + j * 4 + k }
+    # grid.mean # => 11.5
+    # ```
+    def mean : Float64
+      sum / size
+    end
+
+    # Returns the arithmetic mean along *axis*. Axis is specified as an
+    # integer: 0-2 refer to the direction of the first, second or third
+    # basis vector, respectively.
+    #
+    # Raises IndexError is *axis* is out of bounds.
+    #
+    # ```
+    # grid = Grid.new({2, 3, 4}, Bounds[1, 1, 1]) { |i, j, k| i * 12 + j * 4 + k }
+    # grid.mean(axis: 0) # => [5.5, 17.5]
+    # grid.mean(axis: 1) # => [7.5, 11.5, 15.5]
+    # grid.mean(axis: 2) # => [10, 11, 12, 13]
+    # grid.mean(axis: 3) # raises IndexError
+    # ```
+    def mean(axis : Int) : Array(Float64)
+      values = Array(Float64).new @dim[axis]
+      each_axial_slice(axis, reuse: true) do |slice|
+        values << slice.sum / slice.size
+      end
+      values
+    end
+
     def ni : Int32
       dim[0]
     end


### PR DESCRIPTION
This PR adds utility methods to calculate the arithmetic mean of the grid elements and the mean along an axis. The latter is useful for some applications, e.g., compute the work function from the electrostatic potential of a molecular surface