### PR TITLE
Fixed some #each_* methods in views

### DIFF
--- a/spec/core/atom_view_spec.cr
+++ b/spec/core/atom_view_spec.cr
@@ -13,6 +13,14 @@ describe Chem::AtomView do
     end
   end
 
+  describe "#each_chain" do
+    it "yields each chain" do
+      chains = [] of Chem::Chain
+      atoms.each_chain { |chain| chains << chain }
+      chains.map(&.id).should eq ['A', 'B']
+    end
+  end
+
   describe "#each_residue" do
     it "yields each residue" do
       residues = [] of Chem::Residue

--- a/spec/core/atom_view_spec.cr
+++ b/spec/core/atom_view_spec.cr
@@ -1,0 +1,30 @@
+require "../spec_helper"
+
+describe Chem::AtomView do
+  atoms = fake_structure.atoms
+
+  describe "#[]" do
+    it "gets atom by zero-based index" do
+      atoms[4].name.should eq "CB"
+    end
+
+    it "gets atom by serial number" do
+      atoms[serial: 5].name.should eq "CB"
+    end
+  end
+
+  describe "#each_residue" do
+    it "yields each residue" do
+      residues = [] of Chem::Residue
+      atoms.each_residue { |residue| residues << residue }
+      residues.map(&.name).should eq %w(ASP PHE SER)
+      residues.map(&.number).should eq [1, 2, 1]
+    end
+  end
+
+  describe "#size" do
+    it "returns the number of chains" do
+      atoms.size.should eq 25
+    end
+  end
+end

--- a/spec/core/residue_view_spec.cr
+++ b/spec/core/residue_view_spec.cr
@@ -1,0 +1,36 @@
+require "../spec_helper"
+
+describe Chem::ResidueView do
+  residues = load_file("insertion_codes.pdb").residues
+
+  describe "#[]" do
+    it "gets residue by zero-based index" do
+      residues[1].name.should eq "GLY"
+    end
+
+    it "gets residue by serial number" do
+      residues[serial: 76].name.should eq "VAL"
+    end
+
+    it "gets residue by serial number (insertion codes)" do
+      residue = residues[serial: 75]
+      residue.number.should eq 75
+      residue.insertion_code.should eq nil
+      residue.name.should eq "TRP"
+    end
+
+    it "gets residue by serial number and insertion code" do
+      residues = load_file("insertion_codes.pdb").residues
+      residue = residues[75, 'B']
+      residue.number.should eq 75
+      residue.insertion_code.should eq 'B'
+      residue.name.should eq "SER"
+    end
+  end
+
+  describe "#size" do
+    it "returns the number of residues" do
+      residues.size.should eq 7
+    end
+  end
+end

--- a/spec/core/residue_view_spec.cr
+++ b/spec/core/residue_view_spec.cr
@@ -28,6 +28,14 @@ describe Chem::ResidueView do
     end
   end
 
+  describe "#each_chain" do
+    it "yields each chain" do
+      chains = [] of Chem::Chain
+      fake_structure.residues.each_chain { |chain| chains << chain }
+      chains.map(&.id).should eq ['A', 'B']
+    end
+  end
+
   describe "#size" do
     it "returns the number of residues" do
       residues.size.should eq 7

--- a/spec/topology_spec.cr
+++ b/spec/topology_spec.cr
@@ -255,38 +255,3 @@ describe Chem::ResidueCollection do
     end
   end
 end
-
-describe Chem::ResidueView do
-  residues = load_file("insertion_codes.pdb").residues
-
-  describe "#[]" do
-    it "gets residue by zero-based index" do
-      residues[1].name.should eq "GLY"
-    end
-
-    it "gets residue by serial number" do
-      residues[serial: 76].name.should eq "VAL"
-    end
-
-    it "gets residue by serial number (insertion codes)" do
-      residue = residues[serial: 75]
-      residue.number.should eq 75
-      residue.insertion_code.should eq nil
-      residue.name.should eq "TRP"
-    end
-
-    it "gets residue by serial number and insertion code" do
-      residues = load_file("insertion_codes.pdb").residues
-      residue = residues[75, 'B']
-      residue.number.should eq 75
-      residue.insertion_code.should eq 'B'
-      residue.name.should eq "SER"
-    end
-  end
-
-  describe "#size" do
-    it "returns the number of residues" do
-      residues.size.should eq 7
-    end
-  end
-end

--- a/spec/topology_spec.cr
+++ b/spec/topology_spec.cr
@@ -28,26 +28,6 @@ describe Chem::AtomCollection do
   end
 end
 
-describe Chem::AtomView do
-  atoms = fake_structure.atoms
-
-  describe "#[]" do
-    it "gets atom by zero-based index" do
-      atoms[4].name.should eq "CB"
-    end
-
-    it "gets atom by serial number" do
-      atoms[serial: 5].name.should eq "CB"
-    end
-  end
-
-  describe "#size" do
-    it "returns the number of chains" do
-      atoms.size.should eq 25
-    end
-  end
-end
-
 describe Chem::BondArray do
   describe "#[]" do
     st = fake_structure

--- a/src/chem/core/atom_view.cr
+++ b/src/chem/core/atom_view.cr
@@ -51,9 +51,10 @@ module Chem
     end
 
     def each_residue(&block : Residue ->)
+      residues = Set(Residue).new
       each do |atom|
-        yield if atom.residue == prev_residue
-        prev_residue = atom.residue
+        yield atom.residue unless residues.includes?(atom.residue)
+        residues << atom.residue
       end
     end
 

--- a/src/chem/core/atom_view.cr
+++ b/src/chem/core/atom_view.cr
@@ -40,9 +40,10 @@ module Chem
     end
 
     def each_chain(&block : Chain ->)
+      chains = Set(Chain).new
       each do |atom|
-        yield if atom.chain == prev_chain
-        prev_chain = atom.chain
+        yield atom.chain unless chains.includes?(atom.chain)
+        chains << atom.chain
       end
     end
 

--- a/src/chem/core/residue_view.cr
+++ b/src/chem/core/residue_view.cr
@@ -38,9 +38,10 @@ module Chem
     end
 
     def each_chain(&block : Chain ->)
+      chains = Set(Chain).new
       each do |residue|
-        yield if residue.chain == prev_chain
-        prev_chain = residue.chain
+        yield residue.chain unless chains.includes?(residue.chain)
+        chains << residue.chain
       end
     end
 


### PR DESCRIPTION
Some `#each_*` method implementations on `AtomView` and `ResidueView` were incorrect. This PR fixes them plus adds specs