### PR TITLE
Guess topology of unknown atoms

### DIFF
--- a/spec/core/structure_spec.cr
+++ b/spec/core/structure_spec.cr
@@ -28,7 +28,7 @@ describe Chem::Structure do
       other.n_chains.should eq 1
       other.n_residues.should eq 46
       other.n_atoms.should eq 327
-      other.bonds.size.should eq 336
+      other.bonds.size.should eq 337
       other.chains.map(&.id).should eq ['A']
       other.dig('A', 32).name.should eq "CYS"
       other.dig('A', 32).secondary_structure.beta_strand?.should be_true

--- a/spec/topology/perception_spec.cr
+++ b/spec/topology/perception_spec.cr
@@ -281,6 +281,22 @@ describe Topology::Perception do
       residues[0].atoms.map(&.name).should eq %w(N1 C1 C2 O1 C3 O2 H1 H2 H3 H4 C4 H5 H6 H7)
       residues[1].atoms.map(&.name).should eq %w(N1 C1 C2 O1 S1 H1 H2 H3)
     end
+
+    it "guesses the topology of non-standard atoms (#21)" do
+      structure = load_file "5e5v.pdb", topology: :templates
+      structure.dig('A', 1, "N").bonded_atoms.map(&.name).sort!.should eq %w(CA H1 H2 H3)
+      structure.dig('A', 1, "N").bonds.map(&.order).sort!.should eq [1, 1, 1, 1]
+      structure.dig('A', 1, "N").formal_charge.should eq 1
+      structure.dig('A', 7, "OXT").bonded_atoms.map(&.name).should eq %w(C)
+      structure.dig('A', 7, "OXT").bonds.map(&.order).sort!.should eq [1]
+      structure.dig('A', 7, "OXT").formal_charge.should eq -1
+      structure.dig('B', 1, "N").bonded_atoms.map(&.name).sort!.should eq %w(CA H1 H2 H3)
+      structure.dig('B', 1, "N").bonds.map(&.order).sort!.should eq [1, 1, 1, 1]
+      structure.dig('B', 1, "N").formal_charge.should eq 1
+      structure.dig('B', 7, "OXT").bonded_atoms.map(&.name).should eq %w(C)
+      structure.dig('B', 7, "OXT").bonds.map(&.order).sort!.should eq [1]
+      structure.dig('B', 7, "OXT").formal_charge.should eq -1
+    end
   end
 
   describe "#renumber_by_connectivity" do

--- a/src/chem/topology/perception.cr
+++ b/src/chem/topology/perception.cr
@@ -28,7 +28,7 @@ module Chem::Topology::Perception
       atom.formal_charge = if atom.element.ionic?
                              atom.max_valency
                            else
-                             atom.valency - atom.nominal_valency
+                             atom.bonds.sum(&.order) - atom.nominal_valency
                            end
     end
   end

--- a/src/chem/topology/perception.cr
+++ b/src/chem/topology/perception.cr
@@ -157,7 +157,7 @@ module Chem::Topology::Perception
       kdtree.each_neighbor(atom, within: MAX_COVALENT_RADIUS) do |other, d|
         next if other.element.ionic? ||
                 atom.bonded?(other) ||
-                other.valency >= other.max_valency ||
+                (other.element.hydrogen? && other.bonds.size > 0) ||
                 d > PeriodicTable.covalent_cutoff(atom, other)
         if atom.element.hydrogen? && atom.bonds.size == 1
           next unless d < atom.bonds[0].squared_distance


### PR DESCRIPTION
When using templates for topology perception, e.g., reading a PDB, unknown atoms in standard residues (having a matching template) were ignored, leading to incorrect connectivity. This PR generalizes the step that guesses unknown residues individually (ex `#sanitize_residues`), which now guesses all unknown atoms (including atoms in non-standard residues) at once. To make this work, two additional changes were made:

* Remove maximum valency check, so unknown atoms can be bonded to valence-filled standard atoms, e.g., HXT (non-standard) in terminal NH3- could not be bonded to NH2- with valency check on. However, it still applies to hydrogen atoms.
* No longer use `Atom#valency` to re-calculate formal charge because it uses current value internally, and instead compute sum of bonds' order explicitly, e.g., OXT could have its formal charge (-1) assigned from PDB even before guessing bonds, so `Atom#valency` returns 2 instead of 1 during topology guessing, then `formal_charge = atom.valency - atom.max_valency # => 0` instead of -1.

Fixes #21, which it's the same situation happening for non-standard atoms (e.g., H2, H3, OXT) at protein termini.