### PR TITLE
Refactored bond type

### DIFF
--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -34,6 +34,40 @@ describe Chem::Residue do
     end
   end
 
+  describe "#[]" do
+    it "raises when no atom matches atom type" do
+      residue = fake_structure.residues[0]
+      expect_raises IndexError do
+        residue[Topology::AtomType.new("CX9")]
+      end
+    end
+
+    it "raises when atom names match but elements don't" do
+      residue = fake_structure.residues[0]
+      expect_raises IndexError do
+        residue[Topology::AtomType.new("CA", element: "N")]
+      end
+    end
+  end
+
+  describe "#[]?" do
+    it "returns atom that matches atom type" do
+      residue = fake_structure.residues[0]
+      residue[Topology::AtomType.new("CA")]?.should eq residue["CA"]
+      residue[Topology::AtomType.new("OD1")]?.should eq residue["OD1"]
+    end
+
+    it "returns nil when no atom matches atom type" do
+      residue = fake_structure.residues[0]
+      residue[Topology::AtomType.new("CX9")]?.should be_nil
+    end
+
+    it "returns nil when atom names match but elements don't" do
+      residue = fake_structure.residues[0]
+      residue[Topology::AtomType.new("CA", element: "N")]?.should be_nil
+    end
+  end
+
   describe "#bonded?" do
     it "tells if two residues are bonded through any pair of atoms" do
       structure = fake_structure include_bonds: true

--- a/spec/topology/templates_spec.cr
+++ b/spec/topology/templates_spec.cr
@@ -230,7 +230,11 @@ describe Chem::Topology::Templates::Builder do
       residue_t.atom_names.should eq ["C1", "H1", "C2", "H2", "H3", "C3", "H4"]
       residue_t.bonds.size.should eq 6
       residue_t.monomer?.should be_true
-      residue_t.link_bond.should eq Topology::BondType.new("C3", "C1", 2)
+
+      bond_t = residue_t.link_bond.should_not be_nil
+      bond_t[0].name.should eq "C3"
+      bond_t[1].name.should eq "C1"
+      bond_t.order.should eq 2
     end
 
     it "builds a rooted residue" do

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -77,6 +77,38 @@ module Chem
 
     delegate dssp, to: @secondary_structure
 
+    # Returns the atom that matches *atom_t*.
+    #
+    # Atom must match both atom type's name and element, otherwise it
+    # raises `IndexError`.
+    #
+    # ```
+    # residue = Structure.read("peptide.pdb").residues[0]
+    # residue[Topology::AtomType("CA")]               # => <Atom A:TRP1:CA(2)
+    # residue[Topology::AtomType("CA", element: "N")] # raises IndexError
+    # residue[Topology::AtomType("CX")]               # raises IndexError
+    # ```
+    def [](atom_t : Topology::AtomType) : Atom
+      self[atom_t]? || raise IndexError.new "Cannot find atom for atom type: #{atom_t}"
+    end
+
+    # Returns the atom that matches *atom_t*.
+    #
+    # Atom must match both atom type's name and element, otherwise it
+    # returns `nil`.
+    #
+    # ```
+    # residue = Structure.read("peptide.pdb").residues[0]
+    # residue[Topology::AtomType("CA")]               # => <Atom A:TRP1:CA(2)
+    # residue[Topology::AtomType("CA", element: "N")] # => nil
+    # residue[Topology::AtomType("CX")]               # => nil
+    # ```
+    def []?(atom_t : Topology::AtomType) : Atom?
+      if atom = self[atom_t.name]?
+        atom if atom.element == atom_t.element
+      end
+    end
+
     def bonded?(other : self) : Bool
       return false if other.same?(self)
       each_atom.any? do |a1|

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -116,14 +116,16 @@ module Chem
       end
     end
 
-    def bonded?(other : self, lhs : String, rhs : String) : Bool
+    def bonded?(other : self,
+                lhs : Topology::AtomType | String,
+                rhs : Topology::AtomType | String) : Bool
       return false if other.same?(self)
       return false unless (a = self[lhs]?) && (b = other[rhs]?)
       a.bonded? b
     end
 
     def bonded?(other : self, bond_t : Topology::BondType) : Bool
-      bonded? other, bond_t.first, bond_t.second
+      bonded? other, bond_t[0], bond_t[1]
     end
 
     # Returns bonded residues. Residues may be bonded through any atom.

--- a/src/chem/topology/perception.cr
+++ b/src/chem/topology/perception.cr
@@ -110,7 +110,7 @@ module Chem::Topology::Perception
   end
 
   private def assign_bond(residue : Residue, other : Residue, bond_t : BondType) : Nil
-    if (i = residue[bond_t.first]?) && (j = other[bond_t.second]?) && !i.bonded?(j)
+    if (i = residue[bond_t[0]]?) && (j = other[bond_t[1]]?) && !i.bonded?(j)
       i.bonds.add j, bond_t.order if i.within_covalent_distance?(j)
     end
   end
@@ -186,19 +186,16 @@ module Chem::Topology::Perception
 
   private def guess_previous_residue(residue : Residue, link_bond : BondType) : Residue?
     prev_res = nil
-    if atom = residue[link_bond.second]?
-      prev_res = atom.each_bonded_atom.find(&.name.==(link_bond.first)).try &.residue
+    if atom = residue[link_bond[1]]?
+      prev_res = atom.each_bonded_atom.find(&.name.==(link_bond[0].name)).try &.residue
       prev_res ||= atom.each_bonded_atom.find do |atom|
-        element = PeriodicTable[atom_name: link_bond.first]
-        atom.element == element && atom.residue != residue
+        atom.element == link_bond[0].element && atom.residue != residue
       end.try &.residue
     else
-      elements = {PeriodicTable[atom_name: link_bond.first],
-                  PeriodicTable[atom_name: link_bond.second]}
       residue.each_atom do |atom|
-        next unless atom.element == elements[1]
+        next unless atom.element == link_bond[1].element
         prev_res = atom.each_bonded_atom.find do |atom|
-          atom.element == elements[0] && atom.residue != residue
+          atom.element == link_bond[0].element && atom.residue != residue
         end.try &.residue
         break if prev_res
       end

--- a/src/chem/topology/templates/builder.cr
+++ b/src/chem/topology/templates/builder.cr
@@ -123,17 +123,17 @@ module Chem::Topology::Templates
       atom_type?(name) || fatal "Unknown atom type #{name}"
     end
 
-    private def add_bond(atom_name : String, other : String, order : Int = 1)
-      bond = @bonds.find { |bond| bond.includes?(atom_name) && bond.includes?(other) }
+    private def add_bond(atom_t : AtomType, other : AtomType, order : Int = 1)
+      bond = @bonds.find { |bond| bond.includes?(atom_t) && bond.includes?(other) }
       if bond && bond.order != order
-        fatal "Bond #{atom_name}#{bond.to_char}#{other} already exists"
+        fatal "Bond #{atom_t.name}#{bond.to_char}#{other.name} already exists"
       elsif bond.nil?
-        @bonds << BondType.new atom_name, other, order
+        @bonds << BondType.new atom_t, other, order
       end
     end
 
-    private def add_bond(atom_t : AtomType, other : AtomType, order : Int = 1)
-      add_bond atom_t.name, other.name, order
+    private def add_bond(atom_name : String, other : String, order : Int = 1)
+      add_bond atom_type(atom_name), atom_type(other), order
     end
 
     private def add_missing_hydrogens
@@ -199,10 +199,8 @@ module Chem::Topology::Templates
 
     private def parse_bond(spec : String)
       if spec =~ BOND_REGEX
-        _, atom_name, bond_str, other = $~
-        atom_type! atom_name
-        atom_type! other
-        BondType.new atom_name, other, parse_bond_order(bond_str[0])
+        _, lhs, bond_str, rhs = $~
+        BondType.new atom_type!(lhs), atom_type!(rhs), parse_bond_order(bond_str[0])
       else
         parse_exception "Invalid bond specification \"#{spec}\""
       end

--- a/src/chem/topology/templates/detector.cr
+++ b/src/chem/topology/templates/detector.cr
@@ -83,7 +83,7 @@ module Chem::Topology::Templates
           @atom_table[atom_t] = String.build do |io|
             bonded_atoms = res_t.bonded_atoms(atom_t)
             if (bond = res_t.link_bond) && bond.includes?(atom_t)
-              bonded_atoms << res_t[bond.other(atom_t)]
+              bonded_atoms << bond.other(atom_t)
             end
 
             io << atom_t.element.symbol

--- a/src/chem/topology/types.cr
+++ b/src/chem/topology/types.cr
@@ -36,48 +36,55 @@ module Chem::Topology
   end
 
   struct BondType
-    getter first : String
-    getter second : String
+    include Indexable(AtomType)
+
     getter order : Int32
+    delegate size, unsafe_fetch, to: @atoms
 
-    def initialize(@first : String, @second : String, @order : Int = 1)
+    @atoms : StaticArray(AtomType, 2)
+
+    def initialize(lhs : AtomType, rhs : AtomType, @order : Int = 1)
+      @atoms = StaticArray[lhs, rhs]
     end
 
-    def ==(other : BondType) : Bool
-      return false if @order != other.order
-      return true if @first == other.first && @second == other.second
-      @first == other.second && @second == other.first
+    def self.new(lhs : String, rhs : String, order : Int = 1) : self
+      BondType.new AtomType.new(lhs), AtomType.new(rhs), order
     end
 
-    def [](index : Int32) : String
-      case index
-      when 0
-        @first
-      when 1
-        @second
-      else
-        raise IndexError.new
-      end
+    def ==(rhs : self) : Bool
+      return false if @order != rhs.order
+      (self[0] == rhs[0] && self[1] == rhs[1]) ||
+        (self[0] == rhs[1] && self[1] == rhs[0])
     end
 
-    def includes?(atom_name : String) : Bool
-      @first == atom_name || @second == atom_name
-    end
-
-    def includes?(atom_t : AtomType) : Bool
-      includes? atom_t.name
+    def includes?(name : String) : Bool
+      any? &.name.==(name)
     end
 
     def inspect(io : ::IO) : Nil
-      io << "<BondType " << @first << to_char << @second << '>'
+      io << "<BondType " << self[0].name << to_char << self[1].name << '>'
     end
 
-    def other(atom_name : String) : String
-      @first == atom_name ? @second : @first
+    def other(atom_t : AtomType) : AtomType
+      case atom_t
+      when self[0]
+        self[1]
+      when self[1]
+        self[0]
+      else
+        raise ArgumentError.new("Cannot find atom type #{atom_t}")
+      end
     end
 
-    def other(atom_t : AtomType) : String
-      other atom_t.name
+    def other(name : String) : AtomType
+      case name
+      when self[0].name
+        self[1]
+      when self[1].name
+        self[0]
+      else
+        raise ArgumentError.new("Cannot find atom type named #{name}")
+      end
     end
 
     def to_char : Char
@@ -146,7 +153,7 @@ module Chem::Topology
     end
 
     def bonded_atoms(atom_t : AtomType) : Array(AtomType)
-      @bonds.select(&.includes?(atom_t)).map { |bond| self[bond.other(atom_t)] }
+      @bonds.select(&.includes?(atom_t)).map &.other(atom_t)
     end
 
     def bonds : Array(BondType)

--- a/src/chem/topology/types.cr
+++ b/src/chem/topology/types.cr
@@ -35,7 +35,7 @@ module Chem::Topology
     end
   end
 
-  struct BondType
+  class BondType
     include Indexable(AtomType)
 
     getter order : Int32


### PR DESCRIPTION
`BondType` now holds `AtomType` instances instead of raw strings. It also includes `Indexable` now. Together with `Residue#[]` working on atom types, these changes help to clean up some code and, more importantly, to check for both atom name and element when matching atoms to atom types in a consistent way (before one had to guess its element from the atom name, or ignore this check entirely).