### PR TITLE
Narrow bonded residue search by bond type

### DIFF
--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -89,6 +89,12 @@ describe Chem::Residue do
         a2.bonded?(b1, bond_t).should be_false
       end
 
+      it "tells if two residues are bonded by element-based search" do
+        bond_t = Topology::BondType.new "C", "NX"
+        a1.bonded?(a2, bond_t, strict: false).should be_true
+        a2.bonded?(b1, bond_t, strict: false).should be_false
+      end
+
       it "returns false if bond is inverted" do
         a1.bonded?(a2, Topology::BondType.new("N", "C")).should be_false
       end

--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -119,6 +119,10 @@ describe Chem::Residue do
       it "returns false when residue is itself" do
         a1.bonded?(a1, "C", "N").should be_false
       end
+
+      it "returns false when bond order is different" do
+        a1.bonded?(a2, "C", "N", 2).should be_false
+      end
     end
 
     context "given an atom type and element" do
@@ -146,6 +150,11 @@ describe Chem::Residue do
       it "returns false when residue is itself" do
         atom_t = Topology::AtomType.new "C"
         a1.bonded?(a1, atom_t, PeriodicTable::N).should be_false
+      end
+
+      it "returns false when bond order is different" do
+        atom_t = Topology::AtomType.new "C"
+        a1.bonded?(a2, atom_t, PeriodicTable::N, 2).should be_false
       end
     end
 
@@ -175,6 +184,11 @@ describe Chem::Residue do
         atom_t = Topology::AtomType.new "N"
         a1.bonded?(a1, PeriodicTable::C, atom_t).should be_false
       end
+
+      it "returns false when bond order is different" do
+        atom_t = Topology::AtomType.new "N"
+        a1.bonded?(a2, PeriodicTable::C, atom_t, 2).should be_false
+      end
     end
 
     context "given two elements" do
@@ -194,6 +208,10 @@ describe Chem::Residue do
 
       it "returns false when residue is itself" do
         a1.bonded?(a1, PeriodicTable::C, PeriodicTable::N).should be_false
+      end
+
+      it "returns false when bond order is different" do
+        a1.bonded?(a2, PeriodicTable::C, PeriodicTable::N, 2).should be_false
       end
     end
   end

--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -100,6 +100,10 @@ describe Chem::Residue do
       it "returns false when residue is itself" do
         a1.bonded?(a1, Topology::BondType.new("C", "N")).should be_false
       end
+
+      it "returns false when bond order is different" do
+        a1.bonded?(a2, Topology::BondType.new("C", "N", 2)).should be_false
+      end
     end
 
     context "given two atom names" do

--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -107,6 +107,15 @@ describe Chem::Residue do
       residues[3].bonded_residues.map(&.name).should eq %w(CYS)
     end
 
+    it "returns residues bonded via bond type" do
+      residues = load_file("residue_kind_unknown_covalent_ligand.pdb").residues
+      bond_t = Topology::BondType.new("C", "N")
+      residues[0].bonded_residues(bond_t).map(&.name).should eq %w(ALA)
+      residues[1].bonded_residues(bond_t).map(&.name).should eq %w(GLY CYS)
+      residues[2].bonded_residues(bond_t).map(&.name).should eq %w(ALA)
+      residues[3].bonded_residues(bond_t).map(&.name).should eq %w()
+    end
+
     context "given a periodic peptide chain" do
       it "returns two residues for every residue" do
         load_file("hlx_gly.poscar").each_residue do |residue|

--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -229,13 +229,24 @@ describe Chem::Residue do
       residues[3].bonded_residues.map(&.name).should eq %w(CYS)
     end
 
-    it "returns residues bonded via bond type" do
-      residues = load_file("residue_kind_unknown_covalent_ligand.pdb").residues
-      bond_t = Topology::BondType.new("C", "N")
-      residues[0].bonded_residues(bond_t).map(&.name).should eq %w(ALA)
-      residues[1].bonded_residues(bond_t).map(&.name).should eq %w(GLY CYS)
-      residues[2].bonded_residues(bond_t).map(&.name).should eq %w(ALA)
-      residues[3].bonded_residues(bond_t).map(&.name).should eq %w()
+    context "given a bond type" do
+      it "returns residues bonded via X(i)-Y(j)" do
+        residues = load_file("residue_kind_unknown_covalent_ligand.pdb").residues
+        bond_t = Topology::BondType.new("C", "N")
+        residues[0].bonded_residues(bond_t).map(&.name).should eq %w(ALA)
+        residues[1].bonded_residues(bond_t).map(&.name).should eq %w(CYS)
+        residues[2].bonded_residues(bond_t).map(&.name).should eq %w()
+        residues[3].bonded_residues(bond_t).map(&.name).should eq %w()
+      end
+
+      it "returns residues bonded via X(i)-Y(j) or X(j)-Y(i)" do
+        residues = load_file("residue_kind_unknown_covalent_ligand.pdb").residues
+        bond_t = Topology::BondType.new("C", "N")
+        residues[0].bonded_residues(bond_t, forward_only: false).map(&.name).should eq %w(ALA)
+        residues[1].bonded_residues(bond_t, forward_only: false).map(&.name).should eq %w(GLY CYS)
+        residues[2].bonded_residues(bond_t, forward_only: false).map(&.name).should eq %w(ALA)
+        residues[3].bonded_residues(bond_t, forward_only: false).map(&.name).should eq %w()
+      end
     end
 
     context "given a periodic peptide chain" do

--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -91,6 +91,30 @@ describe Chem::Residue do
       structure.dig('A', 1).bonded?(structure.dig('B', 1), bond_t).should be_false
     end
 
+    it "tells if two residues are bonded through atom type-element" do
+      atom_t = Chem::Topology::AtomType.new "C"
+      residues = fake_structure(include_bonds: true).residues
+      residues[0].bonded?(residues[1], atom_t, PeriodicTable::N).should be_true
+      residues[0].bonded?(residues[1], atom_t, PeriodicTable::C).should be_false
+      residues[1].bonded?(residues[2], atom_t, PeriodicTable::N).should be_false
+    end
+
+    it "tells if two residues are bonded through element-atom type" do
+      atom_t = Chem::Topology::AtomType.new "N"
+      residues = fake_structure(include_bonds: true).residues
+      residues[0].bonded?(residues[1], PeriodicTable::C, atom_t).should be_true
+      residues[0].bonded?(residues[1], PeriodicTable::N, atom_t).should be_false
+      residues[1].bonded?(residues[2], PeriodicTable::C, atom_t).should be_false
+    end
+
+    it "tells if two residues are bonded through element-element" do
+      residues = fake_structure(include_bonds: true).residues
+      residues[0].bonded?(residues[1], PeriodicTable::C, PeriodicTable::N).should be_true
+      residues[0].bonded?(residues[1], PeriodicTable::N, PeriodicTable::C).should be_true
+      residues[0].bonded?(residues[1], PeriodicTable::C, PeriodicTable::O).should be_false
+      residues[1].bonded?(residues[2], PeriodicTable::C, PeriodicTable::N).should be_false
+    end
+
     it "returns false when residue is itself" do
       structure = fake_structure include_bonds: true
       structure.dig('A', 1).bonded?(structure.dig('A', 1)).should be_false

--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -253,6 +253,15 @@ describe Chem::Residue do
         residues[2].bonded_residues(bond_t, forward_only: false).map(&.name).should eq %w(ALA)
         residues[3].bonded_residues(bond_t, forward_only: false).map(&.name).should eq %w()
       end
+
+      it "returns bonded residues using fuzzy search" do
+        residues = load_file("residue_kind_unknown_covalent_ligand.pdb").residues
+        bond_t = Topology::BondType.new("C", "NX")
+        residues[0].bonded_residues(bond_t, strict: false).map(&.name).should eq %w(ALA)
+        residues[1].bonded_residues(bond_t, strict: false).map(&.name).should eq %w(CYS)
+        residues[2].bonded_residues(bond_t, strict: false).map(&.name).should eq %w()
+        residues[3].bonded_residues(bond_t, strict: false).map(&.name).should eq %w()
+      end
     end
 
     context "given a periodic peptide chain" do

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -134,11 +134,12 @@ module Chem
     # and insertion code if present (refer to #<=>).
     #
     # ```
-    # residues = Structure.read("ala-phe-asn-thr.pdb")
-    # residues[0].bonded_residues.map(&.name) # => ["PHE"]
-    # residues[1].bonded_residues.map(&.name) # => ["ALA", "ASN"]
-    # residues[2].bonded_residues.map(&.name) # => ["PHE", "THR"]
-    # residues[3].bonded_residues.map(&.name) # => ["ALA", "ASN"]
+    # # Covalent ligand (JG7) is bonded to CYS sidechain
+    # residues = Structure.read("ala-cys-thr-jg7.pdb").residues
+    # residues[0].bonded_residues.map(&.name) # => ["CYS"]
+    # residues[1].bonded_residues.map(&.name) # => ["ALA", "THR", "JG7"]
+    # residues[2].bonded_residues.map(&.name) # => ["CYS"]
+    # residues[3].bonded_residues.map(&.name) # => ["CYS"]
     # ```
     def bonded_residues : Array(Residue)
       residues = Set(Residue).new

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -116,6 +116,10 @@ module Chem
       end
     end
 
+    def bonded?(other : self, bond_t : Topology::BondType) : Bool
+      bonded? other, bond_t[0], bond_t[1]
+    end
+
     def bonded?(other : self,
                 lhs : Topology::AtomType | String,
                 rhs : Topology::AtomType | String) : Bool

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -320,11 +320,25 @@ module Chem
     # residues[2].bonded_residues(bond_t, forward_only: true).map(&.name) # => ["CYS"]
     # residues[3].bonded_residues(bond_t, forward_only: true).map(&.name) # => []
     # ```
+    #
+    # If *strict* is false, bond search checks elements only, and bond
+    # order is ignored (fuzzy search). In the following example, using
+    # `strict: false` makes that any C-N bond is accepted regardless of
+    # atom names or bond order:
+    #
+    # ```
+    # bond_t = Topology::BondType.new "C", "NX", order: 2
+    # residues[0].bonded_residues(bond_t, strict: false).map(&.name) # => ["CYS"]
+    # residues[1].bonded_residues(bond_t, strict: false).map(&.name) # => ["THR"]
+    # residues[2].bonded_residues(bond_t, strict: false).map(&.name) # => []
+    # residues[3].bonded_residues(bond_t, strict: false).map(&.name) # => []
+    # ```
     def bonded_residues(bond_t : Topology::BondType,
-                        forward_only : Bool = true) : Array(Residue)
+                        forward_only : Bool = true,
+                        strict : Bool = true) : Array(Residue)
       bonded_residues.select! do |residue|
-        bonded = bonded?(residue, bond_t)
-        bonded ||= residue.bonded?(self, bond_t) unless forward_only
+        bonded = bonded?(residue, bond_t, strict)
+        bonded ||= residue.bonded?(self, bond_t, strict) unless forward_only
         bonded
       end
     end

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -105,7 +105,7 @@ module Chem
     # ```
     def []?(atom_t : Topology::AtomType) : Atom?
       if atom = self[atom_t.name]?
-        atom if atom.element == atom_t.element
+        atom if atom.match?(atom_t)
       end
     end
 

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -191,33 +191,60 @@ module Chem
     #
     # If *order* is specified, it also check for bond order, otherwise
     # it is ignored:
+    #
+    # ```
+    # residues[0].bonded? residues[1], "C", "N"    # => true
+    # residues[0].bonded? residues[1], "C", "N", 1 # => true
+    # residues[0].bonded? residues[1], "C", "N", 2 # => false
+    # ```
     def bonded?(other : self,
                 lhs : Topology::AtomType | String,
-                rhs : Topology::AtomType | String) : Bool
+                rhs : Topology::AtomType | String,
+                order : Int? = nil) : Bool
       return false if other.same?(self)
       return false unless (a = self[lhs]?) && (b = other[rhs]?)
-      a.bonded? b
+      return false unless bond = a.bonds[b]?
+      bond.order == (order || bond.order)
     end
 
-    def bonded?(other : self, lhs : Topology::AtomType | String, rhs : Element) : Bool
     # :ditto:
+    def bonded?(other : self,
+                lhs : Topology::AtomType | String,
+                rhs : Element,
+                order : Int? = nil) : Bool
       return false if other.same?(self)
       return false unless a = self[lhs]?
-      other.each_atom.any? { |b| b === rhs && a.bonded?(b) }
+      other.each_atom.any? do |b|
+        if b === rhs && (bond = a.bonds[b]?)
+          bond.order == (order || bond.order)
+        end
+      end
     end
 
-    def bonded?(other : self, lhs : Element, rhs : Topology::AtomType | String) : Bool
     # :ditto:
+    def bonded?(other : self,
+                lhs : Element,
+                rhs : Topology::AtomType | String,
+                order : Int? = nil) : Bool
       return false if other.same?(self)
       return false unless b = other[rhs]?
-      @atoms.any? { |a| a === lhs && a.bonded?(b) }
+      @atoms.any? do |a|
+        if a === lhs && (bond = a.bonds[b]?)
+          bond.order == (order || bond.order)
+        end
+      end
     end
 
-    def bonded?(other : self, lhs : Element, rhs : Element) : Bool
     # :ditto:
+    def bonded?(other : self, lhs : Element, rhs : Element, order : Int? = nil) : Bool
       return false if other.same?(self)
       @atoms.any? do |a|
-        a === lhs && other.each_atom.any? { |b| b === rhs && a.bonded?(b) }
+        next unless a === lhs
+        other.each_atom.any? do |b|
+          if b === rhs && (bond = a.bonds[b]?)
+            bond.order == (order || bond.order)
+          end
+        end
       end
     end
 

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -155,8 +155,18 @@ module Chem
     # bond_t = Topology::BondType.new "C", "N", order: 2
     # residues[0].bonded?(residues[1], bond_t) # => false
     # ```
-    def bonded?(other : self, bond_t : Topology::BondType) : Bool
-      bonded? other, bond_t[0], bond_t[1], bond_t.order
+    #
+    # If *strict* is false, it uses elements only instead to look for
+    # bonded atoms, and bond order is ignored.
+    #
+    # ```
+    # bond_t = Topology::BondType.new "C", "NX", order: 2
+    # residues[0].bonded?(residues[1], bond_t)                # => false
+    # residues[0].bonded?(residues[1], bond_t, strict: false) # => true
+    # ```
+    def bonded?(other : self, bond_t : Topology::BondType, strict : Bool = true) : Bool
+      bonded?(other, bond_t[0], bond_t[1], bond_t.order) ||
+        (!strict && bonded?(other, bond_t[0].element, bond_t[1].element))
     end
 
     # Returns true if `self` is bonded to *other* through a bond between

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -140,6 +140,15 @@ module Chem
     # residues[1].bonded?(residues[3], bond_t) # => false
     # ```
     #
+    # Bond check follows the directionality of *bond_t*, that is, the
+    # left and right atoms are looked up in `self` and *other*,
+    # respectively:
+    #
+    # ```
+    # residues[0].bonded?(residues[1], bond_t) # => true
+    # residues[1].bonded?(residues[0], bond_t) # => false
+    # ```
+    #
     # Note that bond order is taken into account, e.g.:
     #
     # ```

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -139,8 +139,15 @@ module Chem
     # residues[2].bonded?(residues[3], bond_t) # => false
     # residues[1].bonded?(residues[3], bond_t) # => false
     # ```
+    #
+    # Note that bond order is taken into account, e.g.:
+    #
+    # ```
+    # bond_t = Topology::BondType.new "C", "N", order: 2
+    # residues[0].bonded?(residues[1], bond_t) # => false
+    # ```
     def bonded?(other : self, bond_t : Topology::BondType) : Bool
-      bonded? other, bond_t[0], bond_t[1]
+      bonded? other, bond_t[0], bond_t[1], bond_t.order
     end
 
     # Returns true if `self` is bonded to *other* through a bond between

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -124,8 +124,23 @@ module Chem
       a.bonded? b
     end
 
-    def bonded?(other : self, bond_t : Topology::BondType) : Bool
-      bonded? other, bond_t[0], bond_t[1]
+    def bonded?(other : self, lhs : Topology::AtomType | String, rhs : Element) : Bool
+      return false if other.same?(self)
+      return false unless a = self[lhs]?
+      other.each_atom.any? { |b| b === rhs && a.bonded?(b) }
+    end
+
+    def bonded?(other : self, lhs : Element, rhs : Topology::AtomType | String) : Bool
+      return false if other.same?(self)
+      return false unless b = other[rhs]?
+      @atoms.any? { |a| a === lhs && a.bonded?(b) }
+    end
+
+    def bonded?(other : self, lhs : Element, rhs : Element) : Bool
+      return false if other.same?(self)
+      @atoms.any? do |a|
+        a === lhs && other.each_atom.any? { |b| b === rhs && a.bonded?(b) }
+      end
     end
 
     # Returns bonded residues. Residues may be bonded through any atom.

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -151,6 +151,29 @@ module Chem
       residues.to_a.sort!
     end
 
+    # Returns residues bonded through *bond_t*.
+    #
+    # Unlike #bonded?, this method ignores bond directionality (A-B), so
+    # residues may be bonded either via A or B.
+    #
+    # Returned residues are ordered by their chain id, residue number
+    # and insertion code if present (refer to #<=>).
+    #
+    # ```
+    # # Covalent ligand (JG7) is bonded to CYS sidechain
+    # residues = Structure.read("ala-cys-thr-jg7.pdb").residues
+    # bond_t = Topology::BondType.new("C", "N")
+    # residues[0].bonded_residues(bond_t).map(&.name) # => ["CYS"]
+    # residues[1].bonded_residues(bond_t).map(&.name) # => ["ALA", "THR"]
+    # residues[2].bonded_residues(bond_t).map(&.name) # => ["CYS"]
+    # residues[3].bonded_residues(bond_t).map(&.name) # => []
+    # ```
+    def bonded_residues(bond_t : Topology::BondType) : Array(Residue)
+      bonded_residues.select! do |residue|
+        bonded?(residue, bond_t) || residue.bonded?(self, bond_t)
+      end
+    end
+
     def chain=(new_chain : Chain) : Chain
       @chain.delete self
       @chain = new_chain

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -289,9 +289,6 @@ module Chem
 
     # Returns residues bonded through *bond_t*.
     #
-    # Unlike #bonded?, this method ignores bond directionality (A-B), so
-    # residues may be bonded either via A or B.
-    #
     # Returned residues are ordered by their chain id, residue number
     # and insertion code if present (refer to #<=>).
     #
@@ -300,13 +297,25 @@ module Chem
     # residues = Structure.read("ala-cys-thr-jg7.pdb").residues
     # bond_t = Topology::BondType.new("C", "N")
     # residues[0].bonded_residues(bond_t).map(&.name) # => ["CYS"]
-    # residues[1].bonded_residues(bond_t).map(&.name) # => ["ALA", "THR"]
-    # residues[2].bonded_residues(bond_t).map(&.name) # => ["CYS"]
+    # residues[1].bonded_residues(bond_t).map(&.name) # => ["THR"]
+    # residues[2].bonded_residues(bond_t).map(&.name) # => []
     # residues[3].bonded_residues(bond_t).map(&.name) # => []
     # ```
-    def bonded_residues(bond_t : Topology::BondType) : Array(Residue)
+    #
+    # If *forward_only* is false, then bond directionality is ignored:
+    #
+    # ```
+    # residues[0].bonded_residues(bond_t, forward_only: true).map(&.name) # => ["CYS"]
+    # residues[1].bonded_residues(bond_t, forward_only: true).map(&.name) # => ["ALA", "THR"]
+    # residues[2].bonded_residues(bond_t, forward_only: true).map(&.name) # => ["CYS"]
+    # residues[3].bonded_residues(bond_t, forward_only: true).map(&.name) # => []
+    # ```
+    def bonded_residues(bond_t : Topology::BondType,
+                        forward_only : Bool = true) : Array(Residue)
       bonded_residues.select! do |residue|
-        bonded?(residue, bond_t) || residue.bonded?(self, bond_t)
+        bonded = bonded?(residue, bond_t)
+        bonded ||= residue.bonded?(self, bond_t) unless forward_only
+        bonded
       end
     end
 


### PR DESCRIPTION
`Residue#bonded_residues` now accepts an optional `BondType`, which narrows the search. Checking for bonded residues via `BondType` relies on `Residue#bonded?` that was updated to make this work. Two additional options were added to control bond directionality and fuzzy search. 