### PR TITLE
Always assign residue types for unknown residues

### DIFF
--- a/src/chem/topology/perception.cr
+++ b/src/chem/topology/perception.cr
@@ -48,12 +48,12 @@ class Chem::Topology::Perception
         bonded_atoms = unmatched_atoms.flat_map &.each_bonded_atom
         assign_formal_charges AtomView.new(unmatched_atoms.to_a.concat(bonded_atoms).uniq)
       end
-      assign_residue_types
     else
       guess_bonds
       guess_residues
       @structure.renumber_by_connectivity
     end
+    assign_residue_types
   end
 
   private getter? has_hydrogens : Bool do


### PR DESCRIPTION
Before it only did it when structure had topology information