### PR TITLE
Residue#previous and #next are now computed properties

### DIFF
--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -319,6 +319,15 @@ describe Chem::Residue do
     end
   end
 
+  describe "#next" do
+    context "given a periodic peptide" do
+      it "returns a residue for the last residue" do
+        residues = load_file("hlx_gly.poscar").residues.map &.next
+        residues.map(&.try(&.number)).should eq (2..13).to_a + [1]
+      end
+    end
+  end
+
   describe "#omega" do
     it "returns torsion angle omega" do
       st = fake_structure include_bonds: true
@@ -370,6 +379,15 @@ describe Chem::Residue do
     it "returns nil when residue is at the start" do
       st = fake_structure include_bonds: true
       st.residues[0].phi?.should be_nil
+    end
+  end
+
+  describe "#previous" do
+    context "given a periodic peptide" do
+      it "returns a residue for 13] + the first residue" do
+        residues = load_file("hlx_gly.poscar").residues.map &.previous
+        residues.map(&.try(&.number)).should eq [13] + (1..12).to_a
+      end
     end
   end
 

--- a/spec/protein/dssp_spec.cr
+++ b/spec/protein/dssp_spec.cr
@@ -2,14 +2,14 @@ require "../spec_helper"
 
 describe Chem::Protein::DSSP do
   it "assigns secondary structure (1cbn)" do
-    st = load_file "1cbn.pdb", topology: :none
+    st = load_file "1cbn.pdb"
     Chem::Protein::DSSP.assign_secondary_structure st
     actual = st.each_residue.select(&.has_backbone?).map(&.dssp).join
     actual.should eq "0EE0SSHHHHHHHHHHHTTT00HHHHHHHHS0EE0SSS000TTS00"
   end
 
   it "assigns secondary structure (1dpo)" do
-    st = load_file "1dpo.pdb", topology: :none
+    st = load_file "1dpo.pdb"
     Chem::Protein::DSSP.assign_secondary_structure st
     expected = "0BS0EE00TT0STTEEEEESSSEEEEEEEEETTEEEE0GGG00SS0EEEES0SBTTS00S00EEEEEEEEE\
                 E0TT00TTT0TT00EEEEESS0000BTTB000B00SS000TT0EEEEEESS000SSS0000SB0EEEEEEB\
@@ -20,14 +20,14 @@ describe Chem::Protein::DSSP do
   end
 
   it "assigns secondary structure (1etl)" do
-    st = load_file "1etl.pdb", topology: :none
+    st = load_file "1etl.pdb"
     Chem::Protein::DSSP.assign_secondary_structure st
     actual = st.each_residue.select(&.has_backbone?).map(&.dssp).join
     actual.should eq "0TT00STTSTT0"
   end
 
   it "assigns secondary structure (3e2o)" do
-    st = load_file "3e2o.pdb", topology: :none
+    st = load_file "3e2o.pdb"
     Chem::Protein::DSSP.assign_secondary_structure st
     expected = "00EE0000TT00HHHHHHHHHHHHHHHHH0TTHHHHT0SHHHHHHHHHHHHTT0BTTTTBSSSTT0GGGSH\
                 HHHT0GGGTTTHHHHHHHHHHHHH0TTS0HHHHHHHHHHHHHHHTT00000B00000000GGG000S00S0\
@@ -39,7 +39,7 @@ describe Chem::Protein::DSSP do
   end
 
   it "assigns secondary structure (4ayo)" do
-    st = load_file "4ayo.pdb", topology: :none
+    st = load_file "4ayo.pdb"
     Chem::Protein::DSSP.assign_secondary_structure st
     expected = "0000HHHHHHHHHHHHHHHHHHHHHHHTTSSEEETTTTEEE0SSSTT0000HHHHHHHHHHHHTT0HHHHH\
                 HHHHHHHHH00000SSEEEHHHIIIIIIHHHHHHHHHH00HHHHHHHHHHHHHHHHHHHTSTT0000SEEE\
@@ -53,7 +53,7 @@ describe Chem::Protein::DSSP do
   end
 
   it "assigns secondary structure (4wfe:G), gaps" do
-    st = load_file "4wfe.pdb", topology: :none
+    st = Structure.from_pdb "spec/data/pdb/4wfe.pdb", chains: ['G']
     Chem::Protein::DSSP.assign_secondary_structure st['G']
     expected = "00EEEE000EEE0TT00EEEEEEEESS0GGGS0EEEEEE0TTS0EEEEEEE0TTT00EEE0GGGTTTEEEE\
                 EETTTTEEEEEE0S00GGG0EEEEEEE0SSS00EE000EEEEE00000B00EEEEE0000EEEEEEEEEEE\
@@ -63,7 +63,7 @@ describe Chem::Protein::DSSP do
   end
 
   it "assigns secondary structure (5jqf)" do
-    st = load_file "5jqf.pdb", topology: :none
+    st = load_file "5jqf.pdb"
     Chem::Protein::DSSP.assign_secondary_structure st
     actual = st.each_residue.select(&.has_backbone?).map(&.dssp).join
     actual.should eq "00EEEEEE0TTTSSE0SEEE000EEEEEE0TTTSSE0SEEE0"

--- a/spec/topology/patcher_spec.cr
+++ b/spec/topology/patcher_spec.cr
@@ -11,6 +11,11 @@ describe Topology::Patcher do
       [r1, r2, r3].all?(&.protein?).should be_true
       [r1, r2, r3].map(&.formal_charge).should eq [-1, 0, 0]
 
+      r1.bonded?(r2).should be_true
+      r1.bonded?(r3).should be_false
+      r2.bonded?(r1).should be_true
+      r2.bonded?(r3).should be_false
+
       r1["N"].bonded_atoms.map(&.name).should eq ["CA"]
 
       r1["N"].bonds[r1["CA"]].order.should eq 1
@@ -22,7 +27,7 @@ describe Topology::Patcher do
       r1["CG"].bonds[r1["OD2"]].order.should eq 1
 
       r1["C"].bonded_atoms.map(&.name).should eq ["CA", "O", "N"]
-      r2["N"].bonded_atoms.map(&.name).should eq ["C", "CA"]
+      r2["N"].bonded_atoms.map(&.name).should eq ["CA", "C"]
 
       r2["N"].bonds[r2["CA"]].order.should eq 1
       r2["CA"].bonds[r2["C"]].order.should eq 1

--- a/src/chem/core/chain.cr
+++ b/src/chem/core/chain.cr
@@ -15,10 +15,6 @@ module Chem
     end
 
     protected def <<(residue : Residue) : self
-      if prev_res = @residues.last?
-        residue.previous = prev_res
-        prev_res.next = residue
-      end
       @residues << residue
       @residue_table[{residue.number, residue.insertion_code}] = residue
       self
@@ -154,13 +150,9 @@ module Chem
     def reset_cache : Nil
       @residue_table.clear
       @residues.sort_by! { |residue| {residue.number, (residue.insertion_code || ' ')} }
-      @residues.each_with_index do |residue, i|
-        residue.previous = @residues[i - 1]?
-        residue.next = @residues[i + 1]?
+      @residues.each do |residue|
         @residue_table[{residue.number, residue.insertion_code}] = residue
       end
-      @residues.first?.try &.previous=(nil)
-      @residues.last?.try &.next=(nil)
     end
   end
 end

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -422,7 +422,7 @@ module Chem
     end
 
     def omega : Float64
-      if (prev_res = previous) && bonded?(prev_res)
+      if prev_res = previous
         Spatial.dihedral prev_res["CA"], prev_res["C"], self["N"], self["CA"]
       else
         raise Error.new "#{self} is terminal"
@@ -430,17 +430,16 @@ module Chem
     end
 
     def omega? : Float64?
-      return nil unless prev_res = self.previous
-      return nil unless bonded? prev_res
-      return nil unless ca1 = prev_res["CA"]?
-      return nil unless c = prev_res["C"]?
-      return nil unless n = self["N"]?
-      return nil unless ca2 = self["CA"]?
-      Spatial.dihedral ca1, c, n, ca2
+      if (ca1 = previous.try(&.[]?("CA"))) &&
+         (c = previous.try(&.[]?("C"))) &&
+         (n = self["N"]?) &&
+         (ca2 = self["CA"]?)
+        Spatial.dihedral ca1, c, n, ca2
+      end
     end
 
     def phi : Float64
-      if (prev_res = previous) && bonded?(prev_res)
+      if prev_res = previous
         Spatial.dihedral prev_res["C"], self["N"], self["CA"], self["C"]
       else
         raise Error.new "#{self} is terminal"
@@ -448,13 +447,12 @@ module Chem
     end
 
     def phi? : Float64?
-      return nil unless prev_res = previous
-      return nil unless bonded? prev_res
-      return nil unless ca1 = prev_res["C"]?
-      return nil unless n = self["N"]?
-      return nil unless ca2 = self["CA"]?
-      return nil unless c = self["C"]?
-      Spatial.dihedral ca1, n, ca2, c
+      if (ca1 = previous.try(&.[]?("C"))) &&
+         (n = self["N"]?) &&
+         (ca2 = self["CA"]?) &&
+         (c = self["C"]?)
+        Spatial.dihedral ca1, n, ca2, c
+      end
     end
 
     # Returns the preceding residue if exists, otherwise `nil`.
@@ -474,7 +472,7 @@ module Chem
     end
 
     def psi : Float64
-      if (next_res = self.next) && bonded?(next_res)
+      if next_res = self.next
         Spatial.dihedral self["N"], self["CA"], self["C"], next_res["N"]
       else
         raise Error.new "#{self} is terminal"
@@ -482,13 +480,12 @@ module Chem
     end
 
     def psi? : Float64?
-      return nil unless next_res = self.next
-      return nil unless bonded? next_res
-      return nil unless n1 = self["N"]?
-      return nil unless ca = self["CA"]?
-      return nil unless c = self["C"]?
-      return nil unless n2 = next_res["N"]?
-      Spatial.dihedral n1, ca, c, n2
+      if (n1 = self["N"]?) &&
+         (ca = self["CA"]?) &&
+         (c = self["C"]?) &&
+         (n2 = self.next.try(&.[]?("N")))
+        Spatial.dihedral n1, ca, c, n2
+      end
     end
 
     def polymer? : Bool

--- a/src/chem/core/structure/builder.cr
+++ b/src/chem/core/structure/builder.cr
@@ -127,9 +127,10 @@ module Chem
     end
 
     def secondary_structure(ri : Residue, rj : Residue, type : Protein::SecondaryStructure)
-      loop do
-        ri.secondary_structure = type
-        break unless ri != rj && (ri = ri.next)
+      @structure.each_residue do |residue|
+        if ri <= residue <= rj
+          residue.secondary_structure = type
+        end
       end
     end
 

--- a/src/chem/spatial/hlxparams.cr
+++ b/src/chem/spatial/hlxparams.cr
@@ -14,10 +14,7 @@ module Chem::Spatial
   end
 
   def hlxparams(res : Residue) : HlxParams?
-    return unless res.protein?
-    return unless prev_res = res.previous
-    return unless next_res = res.next
-    return unless prev_res.bonded?(res) && res.bonded?(next_res)
+    return unless res.protein? && (prev_res = res.previous) && (next_res = res.next)
 
     coord = {
       {ca: prev_res["CA"].coords, c: prev_res["C"].coords},

--- a/src/chem/topology/patcher.cr
+++ b/src/chem/topology/patcher.cr
@@ -6,12 +6,17 @@ module Chem::Topology
     end
 
     def match_and_patch : Nil
+      prev_res = nil
       @residues.each_residue do |residue|
         if res_t = residue.type
           patch residue, res_t
+          if prev_res && (bond_t = res_t.link_bond)
+            patch prev_res, residue, bond_t
+          end
         else
           @unmatched_atoms.concat residue.each_atom
         end
+        prev_res = residue
       end
     end
 
@@ -35,15 +40,6 @@ module Chem::Topology
       end
 
       res_t.bonds.each { |bond_t| patch residue, residue, bond_t }
-      if bond_t = res_t.link_bond
-        patch_link_bond residue, bond_t
-      end
-    end
-
-    def patch_link_bond(residue : Residue, bond_t : BondType)
-      if prev_res = residue.previous
-        patch prev_res, residue, bond_t
-      end
     end
   end
 end

--- a/src/chem/topology/patcher.cr
+++ b/src/chem/topology/patcher.cr
@@ -44,9 +44,6 @@ module Chem::Topology
       if prev_res = residue.previous
         patch prev_res, residue, bond_t
       end
-      if next_res = residue.next
-        patch residue, next_res, bond_t
-      end
     end
   end
 end


### PR DESCRIPTION
Both `Residue#previous` and `#next` were backed up by ivars that were set arbitrarily based on build/read order. They just pointed to the previous/next residue in the structure regardless of topology (different chains) or connectivity. Therefore, one had to check if they were actually bonded before doing any sort of calculation on coordinates.

Given the above, they were refactored and they are now calculated on-the-fly based on current connectivity using the recently-added methods to get bonded residues through a specific bond type. Thus, the meaning of such methods changed a little bit, where now it refers to the preceding and following residues in a polymer chain, but only if there are bonded. Thus, these methods would now return nil at protein gaps, for example, but this doesn't affect much anyways. If one want to iterate over residues regardless of connectivity, just use `chain.each_residue` or something similar.