### PR TITLE
Added PBC support for measurements

### DIFF
--- a/spec/core/residue_spec.cr
+++ b/spec/core/residue_spec.cr
@@ -340,6 +340,15 @@ describe Chem::Residue do
         st.residues[0].omega
       end
     end
+
+    context "given a periodic peptide" do
+      it "returns omega using minimum-image convention" do
+        structure = load_file "hlx_gly.poscar"
+        structure.each_residue do |residue|
+          residue.omega.should be_close -171.64, 1e-2
+        end
+      end
+    end
   end
 
   describe "#omega?" do
@@ -365,6 +374,15 @@ describe Chem::Residue do
       st = fake_structure include_bonds: true
       expect_raises Chem::Error, "A:ASP1 is terminal" do
         st.residues[0].phi
+      end
+    end
+
+    context "given a periodic peptide" do
+      it "returns phi using minimum-image convention" do
+        structure = load_file "hlx_gly.poscar"
+        structure.each_residue do |residue|
+          residue.phi.should be_close -80.33, 1e-2
+        end
       end
     end
   end
@@ -401,6 +419,15 @@ describe Chem::Residue do
       st = fake_structure include_bonds: true
       expect_raises Chem::Error, "A:PHE2 is terminal" do
         st.residues[1].psi
+      end
+    end
+
+    context "given a periodic peptide" do
+      it "returns psi using minimum-image convention" do
+        structure = load_file "hlx_gly.poscar"
+        structure.each_residue do |residue|
+          residue.psi.should be_close 58.2, 1e-2
+        end
       end
     end
   end

--- a/spec/spatial/hlxparams_spec.cr
+++ b/spec/spatial/hlxparams_spec.cr
@@ -24,5 +24,17 @@ describe Chem::Spatial do
       st.residues[2].hlxparams.should be_nil
       st.residues[3].hlxparams.should be_nil
     end
+
+    context "given a periodic peptide" do
+      it "returns helical parameters" do
+        structure = load_file "hlx_gly.poscar"
+        structure.each_residue.map(&.hlxparams).each do |params|
+          params = params.should_not be_nil
+          params.theta.should be_close 166.15, 1e-2
+          params.zeta.should be_close 2.91, 1e-3
+          params.radius.should be_close 1.931, 1e-3
+        end
+      end
+    end
   end
 end

--- a/spec/spatial/measure_spec.cr
+++ b/spec/spatial/measure_spec.cr
@@ -87,6 +87,44 @@ describe Chem::Spatial do
       Chem::Spatial.dihedral(p3, p4, p5, p6).should be_close 59.96536627, 1e-8
       Chem::Spatial.dihedral(p4, p5, p6, p7).should be_close -179.99997738, 1e-8
     end
+
+    context "given an orthogonal cell" do
+      it "returns the dihedral angle using minimum-image convention" do
+        lattice = Lattice.new S[8.77, 9.5, 24.74], 88.22, 80, 70.34
+        [
+          {
+            V[12.305217, 5.828416, 13.900538],
+            V[11.346216, 5.428415, 12.976539],
+            V[10.297216, 4.611416, 13.357537],
+            V[10.218218, 4.169416, 14.671537],
+            -1.147971,
+          },
+          {
+            V[10.642056, 1.612213, 17.949539],
+            V[11.487057, 1.516212, 19.189539],
+            V[3.994056, 0.691212, 19.091537],
+            V[4.774056, 1.122212, 17.841537],
+            49.13,
+          },
+          {
+            V[10.998161, 5.544204, 5.704],
+            V[10.404161, 7.649203, 6.601],
+            V[8.769001, 1.017, 6.131],
+            V[9.765001, 1.086, 5.126],
+            14.647226,
+          },
+          {
+            V[10.013162, 6.172204, 2.062],
+            V[10.640162, 5.509203, 0.89],
+            V[6.923217, 5.407415, 24.324539],
+            V[7.546217, 4.534415, 23.237539],
+            176.497757,
+          },
+        ].each do |(a, b, c, d, expected)|
+          Chem::Spatial.dihedral(a, b, c, d, lattice).should be_close expected, 1e-2
+        end
+      end
+    end
   end
 
   describe ".squared_distance" do

--- a/spec/spatial/measure_spec.cr
+++ b/spec/spatial/measure_spec.cr
@@ -25,6 +25,29 @@ describe Chem::Spatial do
       c = V[8.58, 9.109, 12.362]
       Chem::Spatial.angle(a, b, c).should be_close 125.038109, 1e-6
     end
+
+    context "given a non-orthogonal cell" do
+      it "returns minimum image convention's angle" do
+        lattice = Lattice.new S[8.497, 43.560, 53.640], 85.149, 81.972, 76.480
+        [
+          {V[10.683, 3.591, 15.02],
+           V[11.078, 4.897, 15.343],
+           V[3.775, 5.420, 14.839],
+           120.408979},
+          {V[9.555289, 9.838655, 18.734480],
+           V[10.217254, 9.477283, 17.936636],
+           V[11.142755, 9.133494, 18.416052],
+           107.103893},
+          {V[17.561918, 42.708153, 11.227142],
+           V[7.452369, 1.107032, 10.529989],
+           V[8.070801, 0.735140, 9.680935],
+           108.222383,
+          },
+        ].each do |(a, b, c, expected)|
+          Chem::Spatial.angle(a, b, c, lattice).should be_close expected, 1e-6
+        end
+      end
+    end
   end
 
   describe ".distance" do

--- a/spec/spatial/measure_spec.cr
+++ b/spec/spatial/measure_spec.cr
@@ -18,6 +18,13 @@ describe Chem::Spatial do
     it "returns 90 degrees when vectors are perpendicular to each other" do
       Chem::Spatial.angle(Vector[1, 0, 0], Vector[0, 1, 0]).should eq 90
     end
+
+    it "returns the angle between three vectors" do
+      a = V[9.792, 7.316, 11.31]
+      b = V[9.021, 7.918, 12.368]
+      c = V[8.58, 9.109, 12.362]
+      Chem::Spatial.angle(a, b, c).should be_close 125.038109, 1e-6
+    end
   end
 
   describe ".distance" do

--- a/spec/spatial/measure_spec.cr
+++ b/spec/spatial/measure_spec.cr
@@ -64,5 +64,30 @@ describe Chem::Spatial do
       Chem::Spatial.squared_distance(v1, v2).should eq 17
       Chem::Spatial.squared_distance(v1.inv, v2).should eq 61
     end
+
+    context "given a orthogonal cell" do
+      it "returns minimum image convention's distance" do
+        l = Lattice.new S[10, 20, 30]
+        [
+          {V[1, 1, 1], V[5, 5, 5], 47.999999},
+          {V[1, 1, 1], V[9, 18, 27], 29.0},
+        ].each do |(a, b, expected)|
+          Chem::Spatial.squared_distance(a, b, l).should be_close expected, 1e-3
+        end
+      end
+    end
+
+    context "given a non-orthogonal cell" do
+      it "returns minimum image convention's distance" do
+        l = Lattice.new S[8.77, 9.5, 24.74], 88.22, 80, 70.34
+        [
+          {V[0.82, 1.29, 20.12], V[8.15, 1.41, 19.61], 2.3481},
+          {V[3.37, 3.04, 16.5], V[5.35, 4.07, 17.456], 5.895236},
+          {V[0.4, 1.12, 12.79], V[8.55, 1.99, 13.88], 2.3294},
+        ].each do |(a, b, expected)|
+          Chem::Spatial.squared_distance(a, b, l).should be_close expected, 1e-6
+        end
+      end
+    end
   end
 end

--- a/spec/spatial/measure_spec.cr
+++ b/spec/spatial/measure_spec.cr
@@ -1,4 +1,4 @@
-require "./spec_helper"
+require "../spec_helper"
 
 describe Chem::Spatial do
   v1 = Vector[3.0, 4.0, 0.0]

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -430,7 +430,7 @@ module Chem
          (c = previous.try(&.[]?("C"))) &&
          (n = self["N"]?) &&
          (ca2 = self["CA"]?)
-        Spatial.dihedral ca1, c, n, ca2
+        Spatial.dihedral ca1, c, n, ca2, structure.lattice
       end
     end
 
@@ -443,7 +443,7 @@ module Chem
          (n = self["N"]?) &&
          (ca2 = self["CA"]?) &&
          (c = self["C"]?)
-        Spatial.dihedral ca1, n, ca2, c
+        Spatial.dihedral ca1, n, ca2, c, structure.lattice
       end
     end
 
@@ -472,7 +472,7 @@ module Chem
          (ca = self["CA"]?) &&
          (c = self["C"]?) &&
          (n2 = self.next.try(&.[]?("N")))
-        Spatial.dihedral n1, ca, c, n2
+        Spatial.dihedral n1, ca, c, n2, structure.lattice
       end
     end
 

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -422,11 +422,7 @@ module Chem
     end
 
     def omega : Float64
-      if prev_res = previous
-        Spatial.dihedral prev_res["CA"], prev_res["C"], self["N"], self["CA"]
-      else
-        raise Error.new "#{self} is terminal"
-      end
+      omega? || raise Error.new "#{self} is terminal"
     end
 
     def omega? : Float64?
@@ -439,11 +435,7 @@ module Chem
     end
 
     def phi : Float64
-      if prev_res = previous
-        Spatial.dihedral prev_res["C"], self["N"], self["CA"], self["C"]
-      else
-        raise Error.new "#{self} is terminal"
-      end
+      phi? || raise Error.new "#{self} is terminal"
     end
 
     def phi? : Float64?
@@ -472,11 +464,7 @@ module Chem
     end
 
     def psi : Float64
-      if next_res = self.next
-        Spatial.dihedral self["N"], self["CA"], self["C"], next_res["N"]
-      else
-        raise Error.new "#{self} is terminal"
-      end
+      psi? || raise Error.new "#{self} is terminal"
     end
 
     def psi? : Float64?

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -386,7 +386,7 @@ module Chem
     end
 
     def hlxparams : Spatial::HlxParams?
-      Spatial.hlxparams self
+      Spatial.hlxparams self, structure.lattice
     end
 
     def inspect(io : ::IO) : Nil

--- a/src/chem/protein/dssp.cr
+++ b/src/chem/protein/dssp.cr
@@ -24,6 +24,9 @@ require "./dssp/*"
 #   when residue numbers are not consecutive. This implementation instead checks that
 #   the C(*i*)–N(*i*+1) bond length is within covalent distance.
 #
+# FIXME: it does not work correctly for periodic structures that have
+# bonds between atoms at opposite ends.
+#
 # NOTE: This implementation of DSSP is currently 50% slower than pure C++ solutions, so
 # keep this in mind when assigning the secondary structure of many structures.
 #

--- a/src/chem/spatial.cr
+++ b/src/chem/spatial.cr
@@ -10,6 +10,7 @@ require "./spatial/quaternion"
 require "./spatial/coordinates_proxy"
 require "./spatial/hlxparams"
 require "./spatial/kdtree"
+require "./spatial/measure"
 require "./spatial/pbc"
 
 module Chem::Spatial
@@ -21,53 +22,5 @@ module Chem::Spatial
     def initialize(message = "Coordinates are not periodic")
       super(message)
     end
-  end
-
-  def angle(v1 : Vector, v2 : Vector) : Float64
-    Math.atan2(v1.cross(v2).size, v1.dot(v2)).degrees
-  end
-
-  def angle(a1 : Atom, a2 : Atom, a3 : Atom) : Float64
-    angle a1.coords, a2.coords, a3.coords
-  end
-
-  def angle(p1 : Vector, p2 : Vector, p3 : Vector) : Float64
-    angle p2 - p1, p3 - p2
-  end
-
-  def dihedral(v1 : Vector, v2 : Vector, v3 : Vector) : Float64
-    v12 = v1.cross v2
-    angle = angle v12, v2.cross(v3)
-    v12.dot(v3) < 0 ? -angle : angle
-  end
-
-  def dihedral(a1 : Atom, a2 : Atom, a3 : Atom, a4 : Atom) : Float64
-    dihedral a1.coords, a2.coords, a3.coords, a4.coords
-  end
-
-  def dihedral(p1 : Vector, p2 : Vector, p3 : Vector, p4 : Vector) : Float64
-    dihedral p2 - p1, p3 - p2, p4 - p3
-  end
-
-  def distance(a1 : Atom, a2 : Atom) : Float64
-    distance a1.coords, a2.coords
-  end
-
-  def distance(p1 : Vector, p2 : Vector) : Float64
-    Math.sqrt squared_distance(p1, p2)
-  end
-
-  def distance(q1 : Quaternion, q2 : Quaternion) : Float64
-    # 2 * Math.acos q1.dot(q2)
-    Math.acos 2 * q1.dot(q2)**2 - 1
-  end
-
-  def squared_distance(a1 : Atom, a2 : Atom) : Float64
-    squared_distance a1.coords, a2.coords
-  end
-
-  @[AlwaysInline]
-  def squared_distance(p1 : Vector, p2 : Vector) : Float64
-    (p1.x - p2.x)**2 + (p1.y - p2.y)**2 + (p1.z - p2.z)**2
   end
 end

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -42,4 +42,9 @@ module Chem::Spatial
   def squared_distance(a : Vector, b : Vector) : Float64
     (a.x - b.x)**2 + (a.y - b.y)**2 + (a.z - b.z)**2
   end
+
+  @[AlwaysInline]
+  def squared_distance(a : Vector, b : Vector, lattice : Lattice) : Float64
+    squared_distance a, b.wrap(lattice, around: a)
+  end
 end

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -21,12 +21,19 @@ module Chem::Spatial
     ab.dot(c) < 0 ? -angle : angle
   end
 
-  def dihedral(a : Atom, b : Atom, c : Atom, d : Atom) : Float64
-    dihedral a.coords, b.coords, c.coords, d.coords
+  def dihedral(a : Atom, b : Atom, c : Atom, d : Atom, *args, **options) : Float64
+    dihedral a.coords, b.coords, c.coords, d.coords, *args, **options
   end
 
   def dihedral(a : Vector, b : Vector, c : Vector, d : Vector) : Float64
     dihedral b - a, c - b, d - c
+  end
+
+  def dihedral(a : Vector, b : Vector, c : Vector, d : Vector, lattice : Lattice) : Float64
+    a = a.wrap lattice, around: b
+    c = c.wrap lattice, around: b
+    d = d.wrap lattice, around: c
+    dihedral a, b, c, d
   end
 
   def distance(*args, **options) : Float64

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -3,12 +3,16 @@ module Chem::Spatial
     Math.atan2(a.cross(b).size, a.dot(b)).degrees
   end
 
-  def angle(a : Atom, b : Atom, c : Atom) : Float64
-    angle a.coords, b.coords, c.coords
+  def angle(a : Atom, b : Atom, c : Atom, *args, **options) : Float64
+    angle a.coords, b.coords, c.coords, *args, **options
   end
 
   def angle(a : Vector, b : Vector, c : Vector) : Float64
     angle a - b, c - b
+  end
+
+  def angle(a : Vector, b : Vector, c : Vector, lattice : Lattice) : Float64
+    angle a.wrap(lattice, around: b), b, c.wrap(lattice, around: b)
   end
 
   def dihedral(v1 : Vector, v2 : Vector, v3 : Vector) : Float64

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -15,18 +15,18 @@ module Chem::Spatial
     angle a.wrap(lattice, around: b), b, c.wrap(lattice, around: b)
   end
 
-  def dihedral(v1 : Vector, v2 : Vector, v3 : Vector) : Float64
-    v12 = v1.cross v2
-    angle = angle v12, v2.cross(v3)
-    v12.dot(v3) < 0 ? -angle : angle
+  def dihedral(a : Vector, b : Vector, c : Vector) : Float64
+    ab = a.cross b
+    angle = angle ab, b.cross(c)
+    ab.dot(c) < 0 ? -angle : angle
   end
 
-  def dihedral(a1 : Atom, a2 : Atom, a3 : Atom, a4 : Atom) : Float64
-    dihedral a1.coords, a2.coords, a3.coords, a4.coords
+  def dihedral(a : Atom, b : Atom, c : Atom, d : Atom) : Float64
+    dihedral a.coords, b.coords, c.coords, d.coords
   end
 
-  def dihedral(p1 : Vector, p2 : Vector, p3 : Vector, p4 : Vector) : Float64
-    dihedral p2 - p1, p3 - p2, p4 - p3
+  def dihedral(a : Vector, b : Vector, c : Vector, d : Vector) : Float64
+    dihedral b - a, c - b, d - c
   end
 
   def distance(*args, **options) : Float64

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -8,7 +8,7 @@ module Chem::Spatial
   end
 
   def angle(p1 : Vector, p2 : Vector, p3 : Vector) : Float64
-    angle p2 - p1, p3 - p2
+    angle p1 - p2, p3 - p2
   end
 
   def dihedral(v1 : Vector, v2 : Vector, v3 : Vector) : Float64

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -1,14 +1,14 @@
 module Chem::Spatial
-  def angle(v1 : Vector, v2 : Vector) : Float64
-    Math.atan2(v1.cross(v2).size, v1.dot(v2)).degrees
+  def angle(a : Vector, b : Vector) : Float64
+    Math.atan2(a.cross(b).size, a.dot(b)).degrees
   end
 
-  def angle(a1 : Atom, a2 : Atom, a3 : Atom) : Float64
-    angle a1.coords, a2.coords, a3.coords
+  def angle(a : Atom, b : Atom, c : Atom) : Float64
+    angle a.coords, b.coords, c.coords
   end
 
-  def angle(p1 : Vector, p2 : Vector, p3 : Vector) : Float64
-    angle p1 - p2, p3 - p2
+  def angle(a : Vector, b : Vector, c : Vector) : Float64
+    angle a - b, c - b
   end
 
   def dihedral(v1 : Vector, v2 : Vector, v3 : Vector) : Float64

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -3,16 +3,16 @@ module Chem::Spatial
     Math.atan2(a.cross(b).size, a.dot(b)).degrees
   end
 
-  def angle(a : Atom, b : Atom, c : Atom, *args, **options) : Float64
-    angle a.coords, b.coords, c.coords, *args, **options
+  def angle(a : Atom, b : Atom, c : Atom, lattice : Lattice? = nil) : Float64
+    angle a.coords, b.coords, c.coords, lattice
   end
 
-  def angle(a : Vector, b : Vector, c : Vector) : Float64
+  def angle(a : Vector, b : Vector, c : Vector, lattice : Lattice? = nil) : Float64
+    if lattice
+      a = a.wrap lattice, around: b
+      c = c.wrap lattice, around: b
+    end
     angle a - b, c - b
-  end
-
-  def angle(a : Vector, b : Vector, c : Vector, lattice : Lattice) : Float64
-    angle a.wrap(lattice, around: b), b, c.wrap(lattice, around: b)
   end
 
   def dihedral(a : Vector, b : Vector, c : Vector) : Float64
@@ -25,15 +25,17 @@ module Chem::Spatial
     dihedral a.coords, b.coords, c.coords, d.coords, *args, **options
   end
 
-  def dihedral(a : Vector, b : Vector, c : Vector, d : Vector) : Float64
+  def dihedral(a : Vector,
+               b : Vector,
+               c : Vector,
+               d : Vector,
+               lattice : Lattice? = nil) : Float64
+    if lattice
+      a = a.wrap lattice, around: b
+      c = c.wrap lattice, around: b
+      d = d.wrap lattice, around: c
+    end
     dihedral b - a, c - b, d - c
-  end
-
-  def dihedral(a : Vector, b : Vector, c : Vector, d : Vector, lattice : Lattice) : Float64
-    a = a.wrap lattice, around: b
-    c = c.wrap lattice, around: b
-    d = d.wrap lattice, around: c
-    dihedral a, b, c, d
   end
 
   def distance(*args, **options) : Float64
@@ -45,17 +47,13 @@ module Chem::Spatial
     Math.acos 2 * q1.dot(q2)**2 - 1
   end
 
-  def squared_distance(a1 : Atom, a2 : Atom, *args, **options) : Float64
-    squared_distance a1.coords, a2.coords, *args, **options
+  def squared_distance(a : Atom, b : Atom, lattice : Lattice? = nil) : Float64
+    squared_distance a.coords, b.coords, lattice
   end
 
   @[AlwaysInline]
-  def squared_distance(a : Vector, b : Vector) : Float64
+  def squared_distance(a : Vector, b : Vector, lattice : Lattice? = nil) : Float64
+    b = b.wrap lattice, around: a if lattice
     (a.x - b.x)**2 + (a.y - b.y)**2 + (a.z - b.z)**2
-  end
-
-  @[AlwaysInline]
-  def squared_distance(a : Vector, b : Vector, lattice : Lattice) : Float64
-    squared_distance a, b.wrap(lattice, around: a)
   end
 end

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -25,12 +25,8 @@ module Chem::Spatial
     dihedral p2 - p1, p3 - p2, p4 - p3
   end
 
-  def distance(a1 : Atom, a2 : Atom) : Float64
-    distance a1.coords, a2.coords
-  end
-
-  def distance(p1 : Vector, p2 : Vector) : Float64
-    Math.sqrt squared_distance(p1, p2)
+  def distance(*args, **options) : Float64
+    Math.sqrt squared_distance(*args, **options)
   end
 
   def distance(q1 : Quaternion, q2 : Quaternion) : Float64
@@ -38,8 +34,8 @@ module Chem::Spatial
     Math.acos 2 * q1.dot(q2)**2 - 1
   end
 
-  def squared_distance(a1 : Atom, a2 : Atom) : Float64
-    squared_distance a1.coords, a2.coords
+  def squared_distance(a1 : Atom, a2 : Atom, *args, **options) : Float64
+    squared_distance a1.coords, a2.coords, *args, **options
   end
 
   @[AlwaysInline]

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -1,0 +1,49 @@
+module Chem::Spatial
+  def angle(v1 : Vector, v2 : Vector) : Float64
+    Math.atan2(v1.cross(v2).size, v1.dot(v2)).degrees
+  end
+
+  def angle(a1 : Atom, a2 : Atom, a3 : Atom) : Float64
+    angle a1.coords, a2.coords, a3.coords
+  end
+
+  def angle(p1 : Vector, p2 : Vector, p3 : Vector) : Float64
+    angle p2 - p1, p3 - p2
+  end
+
+  def dihedral(v1 : Vector, v2 : Vector, v3 : Vector) : Float64
+    v12 = v1.cross v2
+    angle = angle v12, v2.cross(v3)
+    v12.dot(v3) < 0 ? -angle : angle
+  end
+
+  def dihedral(a1 : Atom, a2 : Atom, a3 : Atom, a4 : Atom) : Float64
+    dihedral a1.coords, a2.coords, a3.coords, a4.coords
+  end
+
+  def dihedral(p1 : Vector, p2 : Vector, p3 : Vector, p4 : Vector) : Float64
+    dihedral p2 - p1, p3 - p2, p4 - p3
+  end
+
+  def distance(a1 : Atom, a2 : Atom) : Float64
+    distance a1.coords, a2.coords
+  end
+
+  def distance(p1 : Vector, p2 : Vector) : Float64
+    Math.sqrt squared_distance(p1, p2)
+  end
+
+  def distance(q1 : Quaternion, q2 : Quaternion) : Float64
+    # 2 * Math.acos q1.dot(q2)
+    Math.acos 2 * q1.dot(q2)**2 - 1
+  end
+
+  def squared_distance(a1 : Atom, a2 : Atom) : Float64
+    squared_distance a1.coords, a2.coords
+  end
+
+  @[AlwaysInline]
+  def squared_distance(p1 : Vector, p2 : Vector) : Float64
+    (p1.x - p2.x)**2 + (p1.y - p2.y)**2 + (p1.z - p2.z)**2
+  end
+end

--- a/src/chem/spatial/measure.cr
+++ b/src/chem/spatial/measure.cr
@@ -39,7 +39,7 @@ module Chem::Spatial
   end
 
   @[AlwaysInline]
-  def squared_distance(p1 : Vector, p2 : Vector) : Float64
-    (p1.x - p2.x)**2 + (p1.y - p2.y)**2 + (p1.z - p2.z)**2
+  def squared_distance(a : Vector, b : Vector) : Float64
+    (a.x - b.x)**2 + (a.y - b.y)**2 + (a.z - b.z)**2
   end
 end


### PR DESCRIPTION
`Spatial` methods for measurements (distance, angle, dihedral, hlxparams) can now accept a `Lattice` instance, which enables the minimum-image convention. `Residue` methods like `#phi`, `#psi`, etc. were updated as well to use it if available. It solves issues with periodic structures.