### PR TITLE
Atom mutable properties

### DIFF
--- a/src/chem/core/atom.cr
+++ b/src/chem/core/atom.cr
@@ -9,6 +9,7 @@ module Chem
     property element : Element
     property formal_charge : Int32 = 0
     property name : String
+    property mass : Float64
     property occupancy : Float64 = 1
     property partial_charge : Float64 = 0.0
     property residue : Residue
@@ -17,7 +18,7 @@ module Chem
 
     delegate x, y, z, to: @coords
     delegate chain, to: @residue
-    delegate atomic_number, covalent_radius, mass, max_valency, vdw_radius, to: @element
+    delegate atomic_number, covalent_radius, max_valency, vdw_radius, to: @element
 
     def initialize(@name : String,
                    @serial : Int32,
@@ -25,10 +26,12 @@ module Chem
                    @residue : Residue,
                    element : Element? = nil,
                    @formal_charge : Int32 = 0,
+                   mass : Number? = nil,
                    @occupancy : Float64 = 1,
                    @partial_charge : Float64 = 0.0,
                    @temperature_factor : Float64 = 0)
       @element = element || PeriodicTable[atom_name: @name]
+      @mass = (mass || @element.mass).to_f
       @residue << self
     end
 

--- a/src/chem/core/atom.cr
+++ b/src/chem/core/atom.cr
@@ -33,8 +33,18 @@ module Chem
                    @temperature_factor : Float64 = 0,
                    vdw_radius : Number? = nil)
       @element = element || PeriodicTable[atom_name: @name]
-      @mass = (mass || @element.mass).to_f
-      @vdw_radius = (vdw_radius || @element.vdw_radius).to_f
+      @mass = if mass
+                raise ArgumentError.new("Negative mass") if mass < 0
+                mass.to_f
+              else
+                @element.mass
+              end
+      @vdw_radius = if vdw_radius
+                      raise ArgumentError.new("Negative vdW radius") if vdw_radius < 0
+                      vdw_radius.to_f
+                    else
+                      @element.vdw_radius
+                    end
       @residue << self
     end
 

--- a/src/chem/core/atom.cr
+++ b/src/chem/core/atom.cr
@@ -15,10 +15,11 @@ module Chem
     property residue : Residue
     property serial : Int32
     property temperature_factor : Float64 = 0
+    property vdw_radius : Float64
 
     delegate x, y, z, to: @coords
     delegate chain, to: @residue
-    delegate atomic_number, covalent_radius, max_valency, vdw_radius, to: @element
+    delegate atomic_number, covalent_radius, max_valency, to: @element
 
     def initialize(@name : String,
                    @serial : Int32,
@@ -29,9 +30,11 @@ module Chem
                    mass : Number? = nil,
                    @occupancy : Float64 = 1,
                    @partial_charge : Float64 = 0.0,
-                   @temperature_factor : Float64 = 0)
+                   @temperature_factor : Float64 = 0,
+                   vdw_radius : Number? = nil)
       @element = element || PeriodicTable[atom_name: @name]
       @mass = (mass || @element.mass).to_f
+      @vdw_radius = (vdw_radius || @element.vdw_radius).to_f
       @residue << self
     end
 


### PR DESCRIPTION
`Atom#mass` and `#vdw_radius` are now mutable. These could be useful for re-partition of H mass or modifying vdW radii based on the force field values. Default values are taken from the periodic table.