### PR TITLE
Refactored bond assignment from CONECT record

### DIFF
--- a/spec/io/pdb_spec.cr
+++ b/spec/io/pdb_spec.cr
@@ -374,6 +374,13 @@ describe Chem::PDB do
       end
       st.residues.map { |res| {res.number, res.insertion_code} }.should eq resids
     end
+
+    it "does not assign bonds for skipped atoms" do
+      # it triggered IndexError for skipped atoms, but cannot test
+      # whether bonds are assigned from PDB or not since missing bonds
+      # are automatically guessed
+      Structure.from_pdb "spec/data/pdb/1crn.pdb", chains: ['C']
+    end
   end
 end
 

--- a/src/chem/core/structure/builder.cr
+++ b/src/chem/core/structure/builder.cr
@@ -49,6 +49,20 @@ module Chem
       bond
     end
 
+    def bonds(bond_table : Hash(Tuple(Int32, Int32), Int32)) : Nil
+      atom_table = {} of Int32 => Atom
+      atom_serials = Set(Int32).new bond_table.size * 2
+      bond_table.each_key { |(i, j)| atom_serials << i << j }
+      @structure.each_atom do |atom|
+        atom_table[atom.serial] = atom if atom_serials.includes?(atom.serial)
+      end
+      bond_table.each do |(i, j), order|
+        if (lhs = atom_table[i]?) && (rhs = atom_table[j]?)
+          lhs.bonds.add rhs, order
+        end
+      end
+    end
+
     def build : Structure
       transform_aromatic_bonds
       Topology::Perception.new(@structure).guess_topology if @guess_topology

--- a/src/chem/io/formats/pdb.cr
+++ b/src/chem/io/formats/pdb.cr
@@ -296,7 +296,7 @@ module Chem::PDB
     end
 
     private def assign_bonds(builder : Structure::Builder) : Nil
-      builder.bonds @pdb_bonds
+      builder.bonds @pdb_bonds unless @pdb_bonds.empty?
     end
 
     private def assign_secondary_structure(builder : Structure::Builder) : Nil

--- a/src/chem/io/formats/pdb.cr
+++ b/src/chem/io/formats/pdb.cr
@@ -238,9 +238,7 @@ module Chem::PDB
 
     @alt_locs : Hash(Residue, Array(AlternateLocation))?
     @chains : Set(Char)?
-    @offsets : Array(Tuple(Int32, Int32))?
     @seek_bonds = true
-    @serial = 0
     @ss_elements = [] of SecondaryStructureElement
 
     def initialize(input : ::IO | Path | String,
@@ -281,10 +279,6 @@ module Chem::PDB
       end
     end
 
-    private def add_offset_at(serial : Int32) : Nil
-      offsets << {serial, serial - @serial - 1}
-    end
-
     private def add_sec(type : Protein::SecondaryStructure, i : ResidueId, j : ResidueId)
       @ss_elements << SecondaryStructureElement.new type, i, j
     end
@@ -315,10 +309,6 @@ module Chem::PDB
       read(0, 6).rstrip.downcase
     end
 
-    private def offsets : Array(Tuple(Int32, Int32))
-      @offsets ||= [] of Tuple(Int32, Int32)
-    end
-
     private def parse_atom(builder : Structure::Builder) : Nil
       return if (chains = @chains) && !chains.includes?(read(21))
       return if @alt_loc && (alt_loc = read?(16)) && alt_loc != @alt_loc
@@ -333,9 +323,6 @@ module Chem::PDB
         formal_charge: read?(78, 2).try(&.reverse.to_i?) || 0,
         occupancy: read_float(54, 6),
         temperature_factor: read_float(60, 6)
-
-      add_offset_at atom.serial if atom.serial - @serial > 1
-      @serial = atom.serial
 
       if !@alt_loc && (alt_loc = read?(16))
         alt_loc(atom.residue, alt_loc, read(17, 4).strip) << atom
@@ -501,10 +488,6 @@ module Chem::PDB
         alt_locs.sort! { |a, b| b.occupancy <=> a.occupancy }
         alt_locs.each(within: 1..) do |alt_loc|
           alt_loc.each_atom do |atom|
-            unless @pdb_bonds.empty?
-              i = offsets.bsearch_index { |(i, _)| i > atom.serial } || -1
-              offsets.insert i, {atom.serial, 1}
-            end
             residue.delete atom
           end
         end
@@ -527,15 +510,6 @@ module Chem::PDB
         end
       end
       @seek_bonds = false
-    end
-
-    private def serial_to_index(serial : Int32) : Int32
-      index = serial - 1
-      offsets.each do |loc, offset|
-        break if loc > serial
-        index -= offset
-      end
-      index
     end
 
     private alias ResidueId = Tuple(Char, Int32, Char?)

--- a/src/chem/io/formats/pdb.cr
+++ b/src/chem/io/formats/pdb.cr
@@ -302,9 +302,7 @@ module Chem::PDB
     end
 
     private def assign_bonds(builder : Structure::Builder) : Nil
-      @pdb_bonds.each do |(i, j), order|
-        builder.bond serial_to_index(i), serial_to_index(j), order
-      end
+      builder.bonds @pdb_bonds
     end
 
     private def assign_secondary_structure(builder : Structure::Builder) : Nil


### PR DESCRIPTION
This PR removes the atom serial offset logic from PDB parser used to assign bonds from CONECT records efficiently. This hack was relatively confusing and error-prone when atoms are skipped during parsing as shown in #73. Instead, involved atoms in CONECT records are now collected by serial from the structure instance itself thus avoiding index issues.

Fixes #73 