### PR TITLE
Split chains when renumbering by connectivity

### DIFF
--- a/spec/core/chain_spec.cr
+++ b/spec/core/chain_spec.cr
@@ -27,4 +27,14 @@ describe Chem::Chain do
       Chain.new('K', Structure.new).inspect.should eq "<Chain K>"
     end
   end
+
+  describe "#renumber_by_connectivity" do
+    chain = load_file("cylindrin--size-09.pdb").dig 'B'
+    chain.renumber_by_connectivity
+    chain.n_residues.should eq 18
+    chain.residues.map(&.number).should eq (1..18).to_a
+    chain.residues.map(&.name).should eq %w(
+      LEU LYS VAL LEU GLY ASP VAL ILE GLU LEU LYS VAL LEU GLY ASP VAL ILE GLU
+    )
+  end
 end

--- a/spec/core/residue_collection_spec.cr
+++ b/spec/core/residue_collection_spec.cr
@@ -87,56 +87,6 @@ describe Chem::ResidueCollection do
     end
   end
 
-  describe "#renumber_by_connectivity" do
-    it "renumbers residues in ascending order based on the link bond" do
-      structure = load_file "5e5v--unwrapped.poscar", topology: :guess
-      structure.renumber_by_connectivity
-
-      chains = structure.chains
-      chains[0].residues.map(&.number).should eq (1..7).to_a
-      chains[0].residues.map(&.name).should eq %w(ASN PHE GLY ALA ILE LEU SER)
-      chains[1].residues.map(&.number).should eq (1..7).to_a
-      chains[1].residues.map(&.name).should eq %w(UNK PHE GLY ALA ILE LEU SER)
-      chains[2].residues.map(&.name).should eq %w(HOH HOH HOH HOH HOH HOH HOH)
-      chains[2].residues.map(&.number).should eq (1..7).to_a
-      chains[3].residues.map(&.name).should eq %w(UNK)
-      chains[3].residues.map(&.number).should eq [1]
-
-      chains[0].residues[0].previous.should be_nil
-      chains[0].residues[3].previous.try(&.name).should eq "GLY"
-      chains[0].residues[3].next.try(&.name).should eq "ILE"
-      chains[0].residues[-1].next.should be_nil
-    end
-
-    it "renumbers residues of a periodic peptide" do
-      structure = load_file "hlx_gly.poscar", topology: :renumber
-
-      structure.each_residue.cons(2, reuse: true).each do |(a, b)|
-        a["C"].bonded?(b["N"]).should be_true
-        a.next.should eq b
-        b.previous.should eq a
-      end
-    end
-
-    it "does not depend on current residue numbering (#82)" do
-      [
-        "polyala-trp--theta-80.000--c-19.91.poscar",
-        "polyala-trp--theta-180.000--c-10.00.poscar",
-      ].each do |filename|
-        residues = load_file(filename, topology: :guess).residues
-        residues.renumber_by_connectivity
-        residues = residues.to_a.sort_by(&.number)
-        residues.map(&.number).should eq (1..residues.size).to_a
-        residues.each_with_index do |residue, i|
-          j = i + 1
-          j = 0 if j >= residues.size
-          residues[j].number.should eq j + 1
-          residue.bonded?(residues[j]).should be_true
-        end
-      end
-    end
-  end
-
   describe "#reset_secondary_structure" do
     it "sets secondary structure to none" do
       s = load_file "1crn.pdb"

--- a/spec/core/structure_spec.cr
+++ b/spec/core/structure_spec.cr
@@ -121,7 +121,7 @@ describe Chem::Structure do
   describe "#renumber_by_connectivity" do
     it "renumbers residues in ascending order based on the link bond" do
       structure = load_file "5e5v--unwrapped.poscar", topology: :guess
-      structure.renumber_by_connectivity
+      structure.renumber_by_connectivity split_chains: false
 
       chains = structure.chains
       chains[0].residues.map(&.number).should eq (1..7).to_a
@@ -165,6 +165,28 @@ describe Chem::Structure do
           residue.bonded?(residues[j]).should be_true
         end
       end
+    end
+
+    it "does not split chains (#85)" do
+      structure = load_file "cylindrin--size-09.pdb"
+      structure.renumber_by_connectivity split_chains: false
+      structure.chains.map(&.id).should eq "ABC".chars
+      structure.chains.map(&.n_residues).should eq [18] * 3
+      structure.chains.map(&.residues.map(&.number)).should eq [(1..18).to_a] * 3
+      structure.chains.map(&.residues.map(&.name)).should eq [
+        %w(LEU LYS VAL LEU GLY ASP VAL ILE GLU LEU LYS VAL LEU GLY ASP VAL ILE GLU),
+      ] * 3
+    end
+
+    it "splits chains (#85)" do
+      structure = load_file "cylindrin--size-09.pdb"
+      structure.renumber_by_connectivity split_chains: true
+      structure.chains.map(&.id).should eq "ABCDEF".chars
+      structure.chains.map(&.n_residues).should eq [9] * 6
+      structure.chains.map(&.residues.map(&.number)).should eq [(1..9).to_a] * 6
+      structure.chains.map(&.residues.map(&.name)).should eq [
+        %w(LEU LYS VAL LEU GLY ASP VAL ILE GLU),
+      ] * 6
     end
   end
 

--- a/spec/core/structure_spec.cr
+++ b/spec/core/structure_spec.cr
@@ -118,6 +118,56 @@ describe Chem::Structure do
     end
   end
 
+  describe "#renumber_by_connectivity" do
+    it "renumbers residues in ascending order based on the link bond" do
+      structure = load_file "5e5v--unwrapped.poscar", topology: :guess
+      structure.renumber_by_connectivity
+
+      chains = structure.chains
+      chains[0].residues.map(&.number).should eq (1..7).to_a
+      chains[0].residues.map(&.name).should eq %w(ASN PHE GLY ALA ILE LEU SER)
+      chains[1].residues.map(&.number).should eq (1..7).to_a
+      chains[1].residues.map(&.name).should eq %w(UNK PHE GLY ALA ILE LEU SER)
+      chains[2].residues.map(&.name).should eq %w(HOH HOH HOH HOH HOH HOH HOH)
+      chains[2].residues.map(&.number).should eq (1..7).to_a
+      chains[3].residues.map(&.name).should eq %w(UNK)
+      chains[3].residues.map(&.number).should eq [1]
+
+      chains[0].residues[0].previous.should be_nil
+      chains[0].residues[3].previous.try(&.name).should eq "GLY"
+      chains[0].residues[3].next.try(&.name).should eq "ILE"
+      chains[0].residues[-1].next.should be_nil
+    end
+
+    it "renumbers residues of a periodic peptide" do
+      structure = load_file "hlx_gly.poscar", topology: :renumber
+
+      structure.each_residue.cons(2, reuse: true).each do |(a, b)|
+        a["C"].bonded?(b["N"]).should be_true
+        a.next.should eq b
+        b.previous.should eq a
+      end
+    end
+
+    it "does not depend on current residue numbering (#82)" do
+      [
+        "polyala-trp--theta-80.000--c-19.91.poscar",
+        "polyala-trp--theta-180.000--c-10.00.poscar",
+      ].each do |filename|
+        structure = load_file(filename, topology: :guess)
+        structure.renumber_by_connectivity
+        residues = structure.residues.to_a.sort_by(&.number)
+        residues.map(&.number).should eq (1..residues.size).to_a
+        residues.each_with_index do |residue, i|
+          j = i + 1
+          j = 0 if j >= residues.size
+          residues[j].number.should eq j + 1
+          residue.bonded?(residues[j]).should be_true
+        end
+      end
+    end
+  end
+
   describe "#write" do
     structure = Structure.build(guess_topology: false) do
       title "ICN"

--- a/src/chem/core/chain.cr
+++ b/src/chem/core/chain.cr
@@ -134,6 +134,20 @@ module Chem
       @residues.size
     end
 
+    def renumber_by_connectivity : Nil
+      num = 0
+      residues = @residues.to_set
+      while residue = residues.find(&.previous(strict: false, use_numbering: false).nil?) ||
+                      residues.first?
+        while residue && residue.in?(residues)
+          residue.number = (num += 1)
+          residues.delete residue
+          residue = residue.next
+        end
+      end
+      reset_cache
+    end
+
     def structure=(new_structure : Structure) : Structure
       @structure.delete self
       @structure = new_structure

--- a/src/chem/core/chain.cr
+++ b/src/chem/core/chain.cr
@@ -142,7 +142,8 @@ module Chem
         while residue && residue.in?(residues)
           residue.number = (num += 1)
           residues.delete residue
-          residue = residue.next
+          residue = residue.next(strict: false, use_numbering: false) ||
+                    residue.bonded_residues.find(&.in?(residues))
         end
       end
       reset_cache

--- a/src/chem/core/chain.cr
+++ b/src/chem/core/chain.cr
@@ -134,6 +134,8 @@ module Chem
       @residues.size
     end
 
+    # Renumber residues based on bond information. Residue ordering is
+    # computed based on the link bond if available.
     def renumber_by_connectivity : Nil
       num = 0
       residues = @residues.to_set

--- a/src/chem/core/residue.cr
+++ b/src/chem/core/residue.cr
@@ -73,6 +73,16 @@ module Chem
       self
     end
 
+    # Returns `true` if this residue is the same as *rhs*, else `false`.
+    #
+    # NOTE: overrides the equality operator included by `Comparable`,
+    # which uses the `<=>` operator thus returning true for two
+    # different residues that have the same chain id, number and
+    # insertion code.
+    def ==(rhs : self) : Bool
+      same?(rhs)
+    end
+
     # Returns the atom that matches *atom_t*.
     #
     # Atom must match both atom type's name and element, otherwise it

--- a/src/chem/core/residue_collection.cr
+++ b/src/chem/core/residue_collection.cr
@@ -137,21 +137,6 @@ module Chem
       each_residue.compact_map(&.type.try(&.link_bond)).first?
     end
 
-    def renumber_by_connectivity : Nil
-      each_residue.group_by(&.chain).each do |chain, residues|
-        num = 0
-        while residue = residues.find(&.previous(strict: false, use_numbering: false).nil?) ||
-                        residues[0]?
-          while residue && residue.in?(residues)
-            residue.number = (num += 1)
-            residues.reject! &.same?(residue)
-            residue = residue.next
-          end
-        end
-        chain.reset_cache
-      end
-    end
-
     # Sets secondary structure of every residue to none.
     def reset_secondary_structure : self
       each_residue &.sec=(:none)

--- a/src/chem/core/structure.cr
+++ b/src/chem/core/structure.cr
@@ -179,6 +179,21 @@ module Chem
       !!@lattice
     end
 
+    def renumber_by_connectivity : Nil
+      each_residue.group_by(&.chain).each do |chain, residues|
+        num = 0
+        while residue = residues.find(&.previous(strict: false, use_numbering: false).nil?) ||
+                        residues[0]?
+          while residue && residue.in?(residues)
+            residue.number = (num += 1)
+            residues.reject! &.same?(residue)
+            residue = residue.next
+          end
+        end
+        chain.reset_cache
+      end
+    end
+
     def to_s(io : ::IO)
       io << "<Structure"
       io << " " << title.inspect unless title.blank?

--- a/src/chem/core/structure.cr
+++ b/src/chem/core/structure.cr
@@ -180,17 +180,8 @@ module Chem
     end
 
     def renumber_by_connectivity : Nil
-      each_residue.group_by(&.chain).each do |chain, residues|
-        num = 0
-        while residue = residues.find(&.previous(strict: false, use_numbering: false).nil?) ||
-                        residues[0]?
-          while residue && residue.in?(residues)
-            residue.number = (num += 1)
-            residues.reject! &.same?(residue)
-            residue = residue.next
-          end
-        end
-        chain.reset_cache
+      each_chain do |chain|
+        chain.renumber_by_connectivity
       end
     end
 

--- a/src/chem/core/structure.cr
+++ b/src/chem/core/structure.cr
@@ -179,6 +179,14 @@ module Chem
       !!@lattice
     end
 
+    # Renumber chain and residues based on bond information.
+    #
+    # Residue fragments are assigned to unique chains unless
+    # *split_chains* is `false`, which keeps existing chains intact.
+    # Residue ordering is computed based on the link bond if available.
+    #
+    # NOTE: existing chains are reused to re-arrang the residues among
+    # them, so avoid caching them before calling this.
     def renumber_by_connectivity(split_chains : Bool = true) : Nil
       if split_chains
         id = 'A'.pred

--- a/src/chem/core/structure.cr
+++ b/src/chem/core/structure.cr
@@ -179,9 +179,17 @@ module Chem
       !!@lattice
     end
 
-    def renumber_by_connectivity : Nil
-      each_chain do |chain|
-        chain.renumber_by_connectivity
+    def renumber_by_connectivity(split_chains : Bool = true) : Nil
+      if split_chains
+        id = 'A'.pred
+        residues.residue_fragments.each do |residues|
+          chain = dig?(id = id.succ) || Chain.new id, self
+          chain.clear
+          residues.each &.chain=(chain)
+          chain.renumber_by_connectivity
+        end
+      else
+        each_chain &.renumber_by_connectivity
       end
     end
 

--- a/src/chem/topology/perception.cr
+++ b/src/chem/topology/perception.cr
@@ -51,7 +51,7 @@ class Chem::Topology::Perception
     else
       guess_bonds
       guess_residues
-      @structure.renumber_by_connectivity
+      @structure.renumber_by_connectivity split_chains: false
     end
     assign_residue_types
   end


### PR DESCRIPTION
Renumbering residues by connectivity kept intact existing chains even though they consist of multiple fragments. This PR ensures a chain is created for each fragment unless disabled (by the `split_chains` option).

This required the following related changes:

- Move `#renumber_by_connectivity` to `Structure` and `Chain` to ensure the correct handling of new chains. It didn't make much sense to renumber only an arbitrary selection of residues, anyways.
- Fixed equality operator of residue to use identity only (no apparent issue related to that so fix it here)

Fixes #85 